### PR TITLE
Add foundational interfaces for tests

### DIFF
--- a/shared/interfaces/api_models.py
+++ b/shared/interfaces/api_models.py
@@ -7,7 +7,7 @@ API用のリクエスト・レスポンスモデル定義
 from typing import Dict, List, Optional, Any, Union
 from datetime import datetime
 from pydantic import BaseModel, Field
-from .core_types import TaskType, TaskStatus, CrystalAttribute
+from .core_types import TaskType, TaskStatus, CrystalAttribute, CrystalGrowthEvent
 
 
 class APIResponse(BaseModel):
@@ -145,3 +145,58 @@ class ErrorResponse(BaseModel):
     message: str
     details: Dict[str, Any] = {}
     timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class CrystalGrowthRequest(BaseModel):
+    """Crystal growth request"""
+    attribute: CrystalAttribute
+    event_type: CrystalGrowthEvent
+    growth_amount: int = Field(..., ge=1)
+    trigger_context: Dict[str, Any] = {}
+
+
+class CrystalGrowthResponse(BaseModel):
+    """Crystal growth response"""
+    success: bool
+    attribute: CrystalAttribute
+    previous_value: int
+    new_value: int
+    growth_amount: int
+    milestone_reached: bool = False
+    milestone_rewards: List[str] = []
+    therapeutic_message: str = ""
+
+
+class CrystalSystemResponse(BaseModel):
+    """Summary of user's crystal system"""
+    crystals: Dict[str, Dict[str, Any]]
+    total_growth_events: int
+    resonance_level: int
+    active_synergies: List[Dict[str, Any]] = []
+    available_milestones: List[Dict[str, Any]] = []
+
+
+class CrystalResonanceRequest(BaseModel):
+    """Request for crystal resonance calculation"""
+    player_level: int
+    yu_level: int
+    resonance_type: Optional[str] = None
+
+
+class CrystalResonanceResponse(BaseModel):
+    """Response for crystal resonance result"""
+    success: bool
+    resonance_type: str
+    intensity: str
+    bonus_xp: int
+    crystal_bonuses: Dict[str, int] = {}
+    message: str = ""
+
+
+class CrystalMilestoneResponse(BaseModel):
+    """Crystal milestone information"""
+    attribute: CrystalAttribute
+    threshold: int
+    title: str
+    description: str = ""
+    reached: bool = False

--- a/shared/interfaces/mandala_system.py
+++ b/shared/interfaces/mandala_system.py
@@ -1,435 +1,268 @@
-"""
-Mandala System Interface
+"""Mandala system interface using a 9x9 grid of memory cells."""
 
-Mandalaシステムのインターフェース定義
-Requirements: 4.1, 4.3
-"""
+from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple, Any
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from pydantic import BaseModel, Field
-import uuid
-from .core_types import ChapterType, CellStatus
+from typing import Any, Dict, List, Optional, Tuple
 
 
-class MemoryCell(BaseModel):
-    """メモリセル（Mandalaの個別セル）"""
-    cell_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    position: Tuple[int, int]  # (row, col) 0-8の範囲
-    chapter_type: ChapterType
-    status: CellStatus = CellStatus.LOCKED
-    title: str = ""
-    description: str = ""
-    task_id: Optional[str] = None
-    unlock_conditions: List[str] = []
-    xp_reward: int = 0
-    completion_date: Optional[datetime] = None
-    therapeutic_insight: str = ""
-    story_connection: Optional[str] = None
-    
-    def is_center_cell(self) -> bool:
-        """中央セルかどうか判定"""
-        return self.position == (4, 4)
-    
-    def is_core_value_cell(self) -> bool:
-        """コア価値セル（中央周辺）かどうか判定"""
-        row, col = self.position
-        return abs(row - 4) <= 1 and abs(col - 4) <= 1 and not self.is_center_cell()
-    
-    def can_unlock(self, completed_cells: List[str]) -> bool:
-        """アンロック可能かチェック"""
-        if self.status != CellStatus.LOCKED:
-            return False
-        
-        # アンロック条件チェック
-        for condition in self.unlock_conditions:
-            if condition not in completed_cells:
-                return False
-        
-        return True
+class CellStatus(Enum):
+    """Status of a mandala grid cell."""
+
+    LOCKED = "locked"
+    UNLOCKED = "unlocked"
+    COMPLETED = "completed"
+    CORE_VALUE = "core_value"
 
 
-class MandalaGrid(BaseModel):
-    """9x9 Mandalaグリッド"""
-    chapter_type: ChapterType
-    cells: List[List[Optional[MemoryCell]]] = []  # 9x9グリッド
-    center_value: str = ""
-    completion_percentage: float = 0.0
-    unlocked_count: int = 0
-    completed_count: int = 0
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
-    
-    def __init__(self, **data):
-        super().__init__(**data)
-        if not self.cells:
-            self._initialize_grid()
-        self._update_statistics()
-    
-    def _initialize_grid(self):
-        """グリッド初期化"""
-        self.cells = [[None for _ in range(9)] for _ in range(9)]
-        
-        # 中央価値設定
-        center_values = {
-            ChapterType.SELF_DISCIPLINE: "自律性",
-            ChapterType.EMPATHY: "共感力",
-            ChapterType.RESILIENCE: "回復力",
-            ChapterType.CURIOSITY: "好奇心",
-            ChapterType.COMMUNICATION: "コミュニケーション",
-            ChapterType.CREATIVITY: "創造性",
-            ChapterType.COURAGE: "勇気",
-            ChapterType.WISDOM: "知恵"
-        }
-        self.center_value = center_values.get(self.chapter_type, "成長")
-        
-        # セル初期化
-        for row in range(9):
-            for col in range(9):
-                cell = MemoryCell(
-                    position=(row, col),
-                    chapter_type=self.chapter_type,
-                    title=self._generate_cell_title(row, col),
-                    description=self._generate_cell_description(row, col),
-                    unlock_conditions=self._generate_unlock_conditions(row, col)
-                )
-                
-                # 中央セルは最初からアンロック
-                if cell.is_center_cell():
-                    cell.status = CellStatus.AVAILABLE
-                
-                self.cells[row][col] = cell
-    
-    def _generate_cell_title(self, row: int, col: int) -> str:
-        """セルタイトル生成"""
-        if (row, col) == (4, 4):
-            return f"{self.center_value}の核心"
-        
-        # 章タイプに基づくタイトル生成
-        chapter_titles = {
-            ChapterType.SELF_DISCIPLINE: [
-                "朝の習慣", "時間管理", "目標設定", "集中力", "継続力",
-                "自制心", "規律", "責任感", "計画性"
-            ],
-            ChapterType.EMPATHY: [
-                "他者理解", "感情認識", "共感表現", "傾聴", "思いやり",
-                "配慮", "支援", "協調", "理解"
-            ],
-            # 他の章タイプも同様に定義
-        }
-        
-        titles = chapter_titles.get(self.chapter_type, ["成長", "発見", "学び"])
-        index = (row * 9 + col) % len(titles)
-        return titles[index]
-    
-    def _generate_cell_description(self, row: int, col: int) -> str:
-        """セル説明生成"""
-        if (row, col) == (4, 4):
-            return f"{self.center_value}の本質を理解し、実践する"
-        
-        return f"{self._generate_cell_title(row, col)}に関する課題や活動"
-    
-    def _generate_unlock_conditions(self, row: int, col: int) -> List[str]:
-        """アンロック条件生成"""
-        if (row, col) == (4, 4):
-            return []  # 中央は条件なし
-        
-        conditions = []
-        
-        # 中央から近い順にアンロック
-        distance = max(abs(row - 4), abs(col - 4))
-        
-        if distance == 1:
-            # 中央周辺は中央完了が条件
-            conditions.append("center_completed")
-        elif distance == 2:
-            # 2層目は1層目の隣接セル完了が条件
-            adjacent_positions = self._get_adjacent_positions(row, col, distance - 1)
-            for pos in adjacent_positions:
-                conditions.append(f"cell_{pos[0]}_{pos[1]}_completed")
-        
-        return conditions
-    
-    def _get_adjacent_positions(self, row: int, col: int, target_distance: int) -> List[Tuple[int, int]]:
-        """指定距離の隣接位置取得"""
-        positions = []
-        for r in range(max(0, row - 1), min(9, row + 2)):
-            for c in range(max(0, col - 1), min(9, col + 2)):
-                if (r, c) != (row, col):
-                    distance = max(abs(r - 4), abs(c - 4))
-                    if distance == target_distance:
-                        positions.append((r, c))
-        return positions
-    
-    def unlock_cell(self, row: int, col: int) -> bool:
-        """セルアンロック"""
-        if not (0 <= row < 9 and 0 <= col < 9):
-            return False
-        
-        cell = self.cells[row][col]
-        if not cell or cell.status != CellStatus.LOCKED:
-            return False
-        
-        # アンロック条件チェック
-        completed_cells = self._get_completed_cell_ids()
-        if not cell.can_unlock(completed_cells):
-            return False
-        
-        cell.status = CellStatus.AVAILABLE
+@dataclass
+class MemoryCell:
+    """A single cell within the mandala grid."""
+
+    cell_id: str
+    position: Tuple[int, int]
+    status: CellStatus
+    quest_title: str
+    quest_description: str
+    xp_reward: int
+    difficulty: int
+    unlock_requirements: List[str] = field(default_factory=list)
+    completion_time: Optional[datetime] = None
+    linked_story_node: Optional[str] = None
+    therapeutic_focus: Optional[str] = None
+
+
+@dataclass
+class CoreValue:
+    """Core value positioned around the centre of the grid."""
+
+    name: str
+    description: str
+    daily_reminder: str
+    position: Tuple[int, int]
+    therapeutic_principle: str
+
+
+class MandalaGrid:
+    """Represents a 9x9 grid of memory cells with core values in the centre."""
+
+    def __init__(self, uid: str):
+        self.uid = uid
+        self.grid: List[List[Optional[MemoryCell]]] = [[None for _ in range(9)] for _ in range(9)]
+        self.core_values: Dict[Tuple[int, int], CoreValue] = {}
+        self.unlocked_count = 0
+        self.total_cells = 81
         self.last_updated = datetime.utcnow()
-        self._update_statistics()
-        
-        return True
-    
-    def complete_cell(self, row: int, col: int, task_id: Optional[str] = None) -> bool:
-        """セル完了"""
-        if not (0 <= row < 9 and 0 <= col < 9):
-            return False
-        
-        cell = self.cells[row][col]
-        if not cell or cell.status != CellStatus.AVAILABLE:
-            return False
-        
-        cell.status = CellStatus.COMPLETED
-        cell.completion_date = datetime.utcnow()
-        cell.task_id = task_id
-        
-        # 隣接セルのアンロックチェック
-        self._check_adjacent_unlocks(row, col)
-        
-        self.last_updated = datetime.utcnow()
-        self._update_statistics()
-        
-        return True
-    
-    def _check_adjacent_unlocks(self, row: int, col: int):
-        """隣接セルのアンロック可能性チェック"""
-        for r in range(max(0, row - 2), min(9, row + 3)):
-            for c in range(max(0, col - 2), min(9, col + 3)):
-                if (r, c) != (row, col):
-                    self.unlock_cell(r, c)
-    
-    def _get_completed_cell_ids(self) -> List[str]:
-        """完了済みセルID一覧取得"""
-        completed = []
-        
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell and cell.status == CellStatus.COMPLETED:
-                    completed.append(f"cell_{row}_{col}_completed")
-        
-        # 中央セル特別処理
-        center_cell = self.cells[4][4]
-        if center_cell and center_cell.status == CellStatus.COMPLETED:
-            completed.append("center_completed")
-        
-        return completed
-    
-    def _update_statistics(self):
-        """統計更新"""
-        total_cells = 81
-        unlocked = 0
-        completed = 0
-        
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell:
-                    if cell.status in [CellStatus.AVAILABLE, CellStatus.IN_PROGRESS, CellStatus.COMPLETED]:
-                        unlocked += 1
-                    if cell.status == CellStatus.COMPLETED:
-                        completed += 1
-        
-        self.unlocked_count = unlocked
-        self.completed_count = completed
-        self.completion_percentage = (completed / total_cells) * 100
-    
-    def get_cell(self, x: int, y: int) -> Optional[MemoryCell]:
-        """指定位置のセル取得"""
-        if not (0 <= x < 9 and 0 <= y < 9):
-            return None
-        return self.cells[x][y]
-    
+        self._initialize_core_values()
+
+    # ------------------------------------------------------------------
+    # Initialisation helpers
+    # ------------------------------------------------------------------
+    def _initialize_core_values(self) -> None:
+        """Create the nine core values and populate the grid."""
+
+        core_values_data = [
+            {
+                "name": "Core Self",
+                "description": "The authentic self",
+                "daily_reminder": "Remember who you are",
+                "position": (4, 4),
+                "therapeutic_principle": "Self-Acceptance",
+            },
+            {
+                "name": "Compassion",
+                "description": "Be kind to yourself",
+                "daily_reminder": "Offer kindness",
+                "position": (3, 4),
+                "therapeutic_principle": "Self-Compassion",
+            },
+            {
+                "name": "Growth",
+                "description": "Embrace development",
+                "daily_reminder": "Keep growing",
+                "position": (5, 4),
+                "therapeutic_principle": "Growth Mindset",
+            },
+            {
+                "name": "Authenticity",
+                "description": "Live your truth",
+                "daily_reminder": "Stay genuine",
+                "position": (4, 3),
+                "therapeutic_principle": "Authentic Living",
+            },
+            {
+                "name": "Connection",
+                "description": "Reach out to others",
+                "daily_reminder": "You are not alone",
+                "position": (4, 5),
+                "therapeutic_principle": "Social Connection",
+            },
+            {
+                "name": "Present Moment",
+                "description": "Focus on now",
+                "daily_reminder": "Be here now",
+                "position": (3, 3),
+                "therapeutic_principle": "Mindfulness",
+            },
+            {
+                "name": "Values Action",
+                "description": "Act on values",
+                "daily_reminder": "Take meaningful steps",
+                "position": (5, 5),
+                "therapeutic_principle": "Values-Based Action",
+            },
+            {
+                "name": "Acceptance",
+                "description": "Accept experiences",
+                "daily_reminder": "Let it be",
+                "position": (3, 5),
+                "therapeutic_principle": "Radical Acceptance",
+            },
+            {
+                "name": "Commitment",
+                "description": "Stay committed",
+                "daily_reminder": "Choose direction",
+                "position": (5, 3),
+                "therapeutic_principle": "Psychological Flexibility",
+            },
+        ]
+
+        for data in core_values_data:
+            core = CoreValue(**data)
+            self.core_values[core.position] = core
+            x, y = core.position
+            self.grid[x][y] = MemoryCell(
+                cell_id=f"core_value_{x}_{y}",
+                position=core.position,
+                status=CellStatus.CORE_VALUE,
+                quest_title=core.name,
+                quest_description=core.description,
+                xp_reward=0,
+                difficulty=0,
+                therapeutic_focus=core.therapeutic_principle,
+            )
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def _is_valid_position(self, x: int, y: int) -> bool:
+        return 0 <= x < 9 and 0 <= y < 9
+
     def can_unlock(self, x: int, y: int) -> bool:
-        """指定位置のセルがアンロック可能かチェック"""
-        cell = self.get_cell(x, y)
-        if not cell:
+        if not self._is_valid_position(x, y) or self.grid[x][y] is not None:
             return False
-        
-        completed_cells = self._get_completed_cell_ids()
-        return cell.can_unlock(completed_cells)
-    
+
+        adjacent = [
+            (x - 1, y),
+            (x + 1, y),
+            (x, y - 1),
+            (x, y + 1),
+            (x - 1, y - 1),
+            (x - 1, y + 1),
+            (x + 1, y - 1),
+            (x + 1, y + 1),
+        ]
+
+        for ax, ay in adjacent:
+            if self._is_valid_position(ax, ay):
+                cell = self.grid[ax][ay]
+                if cell and cell.status in [
+                    CellStatus.UNLOCKED,
+                    CellStatus.COMPLETED,
+                    CellStatus.CORE_VALUE,
+                ]:
+                    return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Cell manipulation
+    # ------------------------------------------------------------------
+    def unlock_cell(self, x: int, y: int, quest_data: Dict[str, Any]) -> bool:
+        if not self.can_unlock(x, y) or (x, y) in self.core_values:
+            return False
+
+        cell = MemoryCell(
+            cell_id=quest_data.get("cell_id", f"cell_{x}_{y}"),
+            position=(x, y),
+            status=CellStatus.UNLOCKED,
+            quest_title=quest_data.get("quest_title", ""),
+            quest_description=quest_data.get("quest_description", ""),
+            xp_reward=quest_data.get("xp_reward", 10),
+            difficulty=quest_data.get("difficulty", 1),
+            unlock_requirements=quest_data.get("unlock_requirements", []),
+            linked_story_node=quest_data.get("linked_story_node"),
+            therapeutic_focus=quest_data.get("therapeutic_focus"),
+        )
+
+        self.grid[x][y] = cell
+        self.unlocked_count += 1
+        self.last_updated = datetime.utcnow()
+        return True
+
+    def complete_cell(self, x: int, y: int) -> bool:
+        if not self._is_valid_position(x, y):
+            return False
+
+        cell = self.grid[x][y]
+        if not cell or cell.status != CellStatus.UNLOCKED:
+            return False
+
+        cell.status = CellStatus.COMPLETED
+        cell.completion_time = datetime.utcnow()
+        self.last_updated = datetime.utcnow()
+        return True
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def get_cell(self, x: int, y: int) -> Optional[MemoryCell]:
+        if not self._is_valid_position(x, y):
+            return None
+        return self.grid[x][y]
+
     def get_unlocked_cells(self) -> List[MemoryCell]:
-        """アンロック済みセル一覧取得"""
-        unlocked = []
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell and cell.status in [CellStatus.AVAILABLE, CellStatus.IN_PROGRESS, CellStatus.COMPLETED]:
-                    unlocked.append(cell)
-        return unlocked
-    
+        return [
+            cell
+            for row in self.grid
+            for cell in row
+            if cell and cell.status == CellStatus.UNLOCKED
+        ]
+
     def get_completed_cells(self) -> List[MemoryCell]:
-        """完了済みセル一覧取得"""
-        completed = []
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell and cell.status == CellStatus.COMPLETED:
-                    completed.append(cell)
-        return completed
-    
-    @property
-    def total_cells(self) -> int:
-        """総セル数"""
-        return 81
-    
-    @property
-    def core_values(self) -> Dict[str, str]:
-        """コア価値一覧"""
-        return {
-            "center": self.center_value,
-            "chapter": self.chapter_type.value
-        }
-    
-    def to_api_response(self, uid: str) -> Dict[str, Any]:
-        """API応答形式に変換"""
-        grid_data = []
-        
-        for row in range(9):
-            row_data = []
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell:
-                    cell_data = {
-                        "id": cell.cell_id,
-                        "position": cell.position,
-                        "status": cell.status.value,
-                        "title": cell.title,
-                        "description": cell.description,
-                        "xp_reward": cell.xp_reward,
-                        "task_id": cell.task_id,
-                        "completion_date": cell.completion_date.isoformat() if cell.completion_date else None
-                    }
-                else:
-                    cell_data = {"status": "locked"}
-                
-                row_data.append(cell_data)
-            grid_data.append(row_data)
-        
-        return {
-            "uid": uid,
-            "chapter_type": self.chapter_type.value,
-            "center_value": self.center_value,
-            "grid": grid_data,
-            "unlocked_count": self.unlocked_count,
-            "completed_count": self.completed_count,
-            "completion_percentage": self.completion_percentage,
-            "total_cells": 81,
-            "core_values": self.core_values,
-            "last_updated": self.last_updated.isoformat()
-        }
+        return [
+            cell
+            for row in self.grid
+            for cell in row
+            if cell and cell.status == CellStatus.COMPLETED
+        ]
 
 
 class MandalaSystemInterface:
-    """Mandalaシステムインターフェース"""
-    
+    """Simple in-memory interface for managing mandala grids per user."""
+
     def __init__(self):
-        # 実際の実装ではFirestoreを使用
-        self.user_grids: Dict[str, Dict[ChapterType, MandalaGrid]] = {}
-    
-    def get_user_grid(self, uid: str, chapter_type: ChapterType) -> MandalaGrid:
-        """ユーザーのMandalaグリッド取得"""
-        if uid not in self.user_grids:
-            self.user_grids[uid] = {}
-        
-        if chapter_type not in self.user_grids[uid]:
-            self.user_grids[uid][chapter_type] = MandalaGrid(chapter_type=chapter_type)
-        
-        return self.user_grids[uid][chapter_type]
-    
-    def unlock_cell(self, uid: str, chapter_type: ChapterType, row: int, col: int) -> bool:
-        """セルアンロック"""
-        grid = self.get_user_grid(uid, chapter_type)
-        return grid.unlock_cell(row, col)
-    
-    def complete_cell(
-        self, 
-        uid: str, 
-        chapter_type: ChapterType, 
-        row: int, 
-        col: int,
-        task_id: Optional[str] = None
-    ) -> bool:
-        """セル完了"""
-        grid = self.get_user_grid(uid, chapter_type)
-        return grid.complete_cell(row, col, task_id)
-    
-    def get_grid_api_response(self, uid: str, chapter_type: ChapterType) -> Dict[str, Any]:
-        """グリッドAPI応答取得"""
-        grid = self.get_user_grid(uid, chapter_type)
-        return grid.to_api_response(uid)
-    
-    def get_user_progress_summary(self, uid: str) -> Dict[str, Any]:
-        """ユーザー進捗サマリー取得"""
-        if uid not in self.user_grids:
-            return {
-                "uid": uid,
-                "total_chapters": 0,
-                "completed_chapters": 0,
-                "total_cells": 0,
-                "completed_cells": 0,
-                "overall_completion": 0.0,
-                "chapter_progress": {}
-            }
-        
-        total_cells = 0
-        completed_cells = 0
-        completed_chapters = 0
-        chapter_progress = {}
-        
-        for chapter_type, grid in self.user_grids[uid].items():
-            total_cells += 81
-            completed_cells += grid.completed_count
-            
-            chapter_progress[chapter_type.value] = {
-                "completion_percentage": grid.completion_percentage,
-                "completed_count": grid.completed_count,
-                "unlocked_count": grid.unlocked_count
-            }
-            
-            if grid.completion_percentage >= 100.0:
-                completed_chapters += 1
-        
-        overall_completion = (completed_cells / total_cells * 100) if total_cells > 0 else 0.0
-        
+        self.grids: Dict[str, MandalaGrid] = {}
+
+    def get_or_create_grid(self, uid: str) -> MandalaGrid:
+        if uid not in self.grids:
+            self.grids[uid] = MandalaGrid(uid)
+        return self.grids[uid]
+
+    def unlock_cell_for_user(self, uid: str, x: int, y: int, quest_data: Dict[str, Any]) -> bool:
+        grid = self.get_or_create_grid(uid)
+        return grid.unlock_cell(x, y, quest_data)
+
+    def complete_cell_for_user(self, uid: str, x: int, y: int) -> bool:
+        grid = self.get_or_create_grid(uid)
+        return grid.complete_cell(x, y)
+
+    def get_grid_api_response(self, uid: str) -> Dict[str, Any]:
+        grid = self.get_or_create_grid(uid)
         return {
             "uid": uid,
-            "total_chapters": len(self.user_grids[uid]),
-            "completed_chapters": completed_chapters,
-            "total_cells": total_cells,
-            "completed_cells": completed_cells,
-            "overall_completion": overall_completion,
-            "chapter_progress": chapter_progress
+            "unlocked_count": grid.unlocked_count,
+            "total_cells": grid.total_cells,
         }
-    
-    # 統合テスト用の互換性メソッド
-    def get_or_create_grid(self, uid: str, chapter_type: ChapterType = ChapterType.SELF_DISCIPLINE) -> MandalaGrid:
-        """グリッド取得または作成（統合テスト用）"""
-        return self.get_user_grid(uid, chapter_type)
-    
-    def unlock_cell_for_user(self, uid: str, x: int, y: int, quest_data: Dict[str, Any]) -> bool:
-        """ユーザー用セルアンロック（統合テスト用）"""
-        # デフォルトのchapter_typeを使用
-        return self.unlock_cell(uid, ChapterType.SELF_DISCIPLINE, x, y)
-    
-    def complete_cell_for_user(self, uid: str, x: int, y: int) -> bool:
-        """ユーザー用セル完了（統合テスト用）"""
-        # デフォルトのchapter_typeを使用
-        return self.complete_cell(uid, ChapterType.SELF_DISCIPLINE, x, y)
-    
-    def get_daily_reminder_for_user(self, uid: str) -> str:
-        """ユーザー用日次リマインダー取得（統合テスト用）"""
-        return f"{uid}さん、今日もMandalaで成長の一歩を踏み出しましょう！"
+

--- a/shared/repositories/__init__.py
+++ b/shared/repositories/__init__.py
@@ -1,45 +1,6 @@
-"""
-Repository layer initialization
-Exports all repository classes for easy importing
-"""
+"""Repository package exports."""
 
 from .base_repository import BaseRepository, CachedRepository
-from .user_repository import UserRepository
-from .task_repository import TaskRepository
-from .story_repository import StoryRepository
-from .mood_repository import MoodRepository
-from .mandala_repository import MandalaRepository
-from .game_state_repository import GameStateRepository
-from .guardian_repository import GuardianRepository
-from .adhd_support_repository import ADHDSupportRepository, ADHDSupportSettings
-from .therapeutic_safety_repository import (
-    TherapeuticSafetyRepository, 
-    SafetyLog, 
-    ContentType, 
-    InterventionType
-)
 
-__all__ = [
-    # Base classes
-    "BaseRepository",
-    "CachedRepository",
-    
-    # Core repositories
-    "UserRepository",
-    "TaskRepository", 
-    "StoryRepository",
-    "MoodRepository",
-    "MandalaRepository",
-    "GameStateRepository",
-    "GuardianRepository",
-    
-    # Specialized repositories
-    "ADHDSupportRepository",
-    "TherapeuticSafetyRepository",
-    
-    # Data classes and enums
-    "ADHDSupportSettings",
-    "SafetyLog",
-    "ContentType",
-    "InterventionType"
-]
+__all__ = ["BaseRepository", "CachedRepository"]
+

--- a/shared/utils/exceptions.py
+++ b/shared/utils/exceptions.py
@@ -24,10 +24,24 @@ class ValidationError(TherapeuticGameError):
 
 class BusinessLogicError(TherapeuticGameError):
     """Business logic error"""
-    
+
     def __init__(self, message: str, operation: Optional[str] = None):
         super().__init__(message, "BUSINESS_LOGIC_ERROR")
         self.operation = operation
+
+
+class NotFoundError(TherapeuticGameError):
+    """Generic not found error"""
+
+    def __init__(self, message: str = "Resource not found"):
+        super().__init__(message, "NOT_FOUND")
+
+
+class DatabaseError(TherapeuticGameError):
+    """Generic database operation error"""
+
+    def __init__(self, message: str = "Database operation failed"):
+        super().__init__(message, "DATABASE_ERROR")
 
 class AuthenticationError(TherapeuticGameError):
     """Authentication related errors"""
@@ -170,6 +184,7 @@ class ConfigurationError(TherapeuticGameError):
 EXCEPTION_STATUS_MAP = {
     ValidationError: 400,
     BusinessLogicError: 400,
+    NotFoundError: 404,
     AuthenticationError: 401,
     AuthorizationError: 403,
     UserNotFoundError: 404,
@@ -177,6 +192,7 @@ EXCEPTION_STATUS_MAP = {
     ItemNotFoundError: 404,
     DailyTaskLimitExceededError: 429,
     RateLimitExceededError: 429,
+    DatabaseError: 500,
     DatabaseConnectionError: 503,
     ExternalAPIError: 502,
     TherapeuticGameError: 500,  # Default for base exception


### PR DESCRIPTION
## Summary
- add missing crystal request/response models and generic error types
- implement mandala grid and validation stubs
- include resonance calculator and streamlined repository exports

## Testing
- `pytest shared/tests/ -v --cov=shared --cov-report=xml --cov-report=html` *(fails: 75 failed, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6894aac7f79c8333a6453bb977e84044