### PR TITLE
Add generic repository exceptions

### DIFF
--- a/shared/repositories/__init__.py
+++ b/shared/repositories/__init__.py
@@ -6,7 +6,6 @@ Exports all repository classes for easy importing
 from .base_repository import BaseRepository, CachedRepository
 from .user_repository import UserRepository
 from .task_repository import TaskRepository
-from .story_repository import StoryRepository
 from .mood_repository import MoodRepository
 from .mandala_repository import MandalaRepository
 from .game_state_repository import GameStateRepository
@@ -27,7 +26,6 @@ __all__ = [
     # Core repositories
     "UserRepository",
     "TaskRepository", 
-    "StoryRepository",
     "MoodRepository",
     "MandalaRepository",
     "GameStateRepository",

--- a/shared/utils/exceptions.py
+++ b/shared/utils/exceptions.py
@@ -37,9 +37,21 @@ class AuthenticationError(TherapeuticGameError):
 
 class AuthorizationError(TherapeuticGameError):
     """Authorization related errors"""
-    
+
     def __init__(self, message: str = "こ"):
         super().__init__(message, "AUTHORIZATION_ERROR")
+
+class NotFoundError(TherapeuticGameError):
+    """Generic not found error for missing resources."""
+
+    def __init__(self, message: str = "Resource not found"):
+        super().__init__(message, "NOT_FOUND")
+
+class DatabaseError(TherapeuticGameError):
+    """Generic database operation error."""
+
+    def __init__(self, message: str = "Database operation failed"):
+        super().__init__(message, "DATABASE_ERROR")
 
 class UserNotFoundError(TherapeuticGameError):
     """User not found error"""
@@ -172,11 +184,13 @@ EXCEPTION_STATUS_MAP = {
     BusinessLogicError: 400,
     AuthenticationError: 401,
     AuthorizationError: 403,
+    NotFoundError: 404,
     UserNotFoundError: 404,
     TaskNotFoundError: 404,
     ItemNotFoundError: 404,
     DailyTaskLimitExceededError: 429,
     RateLimitExceededError: 429,
+    DatabaseError: 500,
     DatabaseConnectionError: 503,
     ExternalAPIError: 502,
     TherapeuticGameError: 500,  # Default for base exception


### PR DESCRIPTION
## Summary
- add generic `NotFoundError` and `DatabaseError` exceptions used by repositories
- map new exceptions to appropriate HTTP status codes
- remove invalid `StoryRepository` export from repository package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt', 83 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6894b78026748333b2166fcaf053ca05