### PR TITLE
Restore legacy interfaces and models for tests

### DIFF
--- a/shared/interfaces/api_models.py
+++ b/shared/interfaces/api_models.py
@@ -7,7 +7,7 @@ API用のリクエスト・レスポンスモデル定義
 from typing import Dict, List, Optional, Any, Union
 from datetime import datetime
 from pydantic import BaseModel, Field
-from .core_types import TaskType, TaskStatus, CrystalAttribute
+from .core_types import TaskType, TaskStatus, CrystalAttribute, CrystalGrowthEvent
 
 
 class APIResponse(BaseModel):
@@ -145,3 +145,54 @@ class ErrorResponse(BaseModel):
     message: str
     details: Dict[str, Any] = {}
     timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+# Crystal system API models
+class CrystalGrowthRequest(BaseModel):
+    """クリスタル成長リクエスト"""
+    attribute: CrystalAttribute
+    event_type: CrystalGrowthEvent
+    growth_amount: int = Field(..., ge=0)
+    trigger_context: Dict[str, Any] = {}
+
+
+class CrystalGrowthResponse(BaseModel):
+    """クリスタル成長レスポンス"""
+    success: bool
+    attribute: CrystalAttribute
+    previous_value: int
+    new_value: int
+    growth_amount: int
+    milestone_reached: bool = False
+    milestone_rewards: List[str] = []
+    therapeutic_message: str = ""
+
+
+class CrystalSystemResponse(BaseModel):
+    """ユーザークリスタルシステム状態"""
+    crystals: Dict[str, Dict[str, Any]]
+    total_growth_events: int
+    resonance_level: int
+    active_synergies: List[Dict[str, Any]] = []
+    available_milestones: List[Dict[str, Any]] = []
+
+
+class CrystalResonanceRequest(BaseModel):
+    """クリスタル共鳴リクエスト"""
+    uid: str
+    player_level: int
+    yu_level: int
+
+
+class CrystalResonanceResponse(BaseModel):
+    """クリスタル共鳴レスポンス"""
+    success: bool
+    event: Dict[str, Any] = {}
+
+
+class CrystalMilestoneResponse(BaseModel):
+    """クリスタルマイルストーンレスポンス"""
+    success: bool
+    milestone: Dict[str, Any]
+    rewards: List[str] = []
+    therapeutic_message: str = ""

--- a/shared/interfaces/mandala_system.py
+++ b/shared/interfaces/mandala_system.py
@@ -1,435 +1,401 @@
 """
 Mandala System Interface
 
-Mandalaシステムのインターフェース定義
+9x9[UNICODE_30B0]ACT[UNICODE_7642]
+[UNICODE_30B0]Mandala[UNICODE_30B7]
+
 Requirements: 4.1, 4.3
 """
 
 from typing import Dict, List, Optional, Tuple, Any
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from pydantic import BaseModel, Field
-import uuid
-from .core_types import ChapterType, CellStatus
+import json
 
 
-class MemoryCell(BaseModel):
-    """メモリセル（Mandalaの個別セル）"""
-    cell_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    position: Tuple[int, int]  # (row, col) 0-8の範囲
-    chapter_type: ChapterType
-    status: CellStatus = CellStatus.LOCKED
-    title: str = ""
-    description: str = ""
-    task_id: Optional[str] = None
-    unlock_conditions: List[str] = []
-    xp_reward: int = 0
-    completion_date: Optional[datetime] = None
-    therapeutic_insight: str = ""
-    story_connection: Optional[str] = None
+class CellStatus(Enum):
+    """[UNICODE_30BB]"""
+    LOCKED = "locked"
+    UNLOCKED = "unlocked"
+    COMPLETED = "completed"
+    CORE_VALUE = "core_value"
+
+
+@dataclass
+class MemoryCell:
+    """[UNICODE_30E1]"""
+    cell_id: str
+    position: Tuple[int, int]  # (x, y) coordinates
+    status: CellStatus
+    quest_title: str
+    quest_description: str
+    xp_reward: int
+    difficulty: int  # 1-5
+    unlock_requirements: List[str] = field(default_factory=list)
+    completion_time: Optional[datetime] = None
+    linked_story_node: Optional[str] = None
+    therapeutic_focus: Optional[str] = None
+
+
+@dataclass
+class CoreValue:
+    """[UNICODE_4E2D]ACT[UNICODE_7642]"""
+    name: str
+    description: str
+    daily_reminder: str
+    position: Tuple[int, int]
+    therapeutic_principle: str
+
+
+class MandalaGrid:
+    """
+    9x9 Mandala[UNICODE_30B0]
     
-    def is_center_cell(self) -> bool:
-        """中央セルかどうか判定"""
-        return self.position == (4, 4)
+    [UNICODE_4E2D]ACT[UNICODE_7642]
+    81[UNICODE_500B]
+    """
     
-    def is_core_value_cell(self) -> bool:
-        """コア価値セル（中央周辺）かどうか判定"""
-        row, col = self.position
-        return abs(row - 4) <= 1 and abs(col - 4) <= 1 and not self.is_center_cell()
+    def __init__(self, uid: str):
+        self.uid = uid
+        self.grid: List[List[Optional[MemoryCell]]] = [[None for _ in range(9)] for _ in range(9)]
+        self.core_values: Dict[Tuple[int, int], CoreValue] = {}
+        self.unlocked_count = 0
+        self.total_cells = 81
+        self.last_updated = datetime.now()
+        
+        # [UNICODE_4E2D]
+        self._initialize_core_values()
     
-    def can_unlock(self, completed_cells: List[str]) -> bool:
-        """アンロック可能かチェック"""
-        if self.status != CellStatus.LOCKED:
+    def _initialize_core_values(self) -> None:
+        """[UNICODE_4E2D]ACT[UNICODE_7642]"""
+        core_values_data = [
+            {
+                "name": "Core Self",
+                "description": "[UNICODE_771F]",
+                "daily_reminder": "[UNICODE_4ECA]",
+                "position": (4, 4),  # [UNICODE_4E2D]
+                "therapeutic_principle": "Self-Acceptance"
+            },
+            {
+                "name": "Compassion",
+                "description": "[UNICODE_6148]",
+                "daily_reminder": "[UNICODE_81EA]",
+                "position": (3, 4),
+                "therapeutic_principle": "Self-Compassion"
+            },
+            {
+                "name": "Growth",
+                "description": "[UNICODE_6210]",
+                "daily_reminder": "[UNICODE_5C0F]",
+                "position": (5, 4),
+                "therapeutic_principle": "Growth Mindset"
+            },
+            {
+                "name": "Authenticity",
+                "description": "[UNICODE_771F]",
+                "daily_reminder": "[UNICODE_81EA]",
+                "position": (4, 3),
+                "therapeutic_principle": "Authentic Living"
+            },
+            {
+                "name": "Connection",
+                "description": "[UNICODE_3064]",
+                "daily_reminder": "[UNICODE_4EBA]",
+                "position": (4, 5),
+                "therapeutic_principle": "Social Connection"
+            },
+            {
+                "name": "Present Moment",
+                "description": "[UNICODE_4ECA]",
+                "daily_reminder": "[UNICODE_4ECA]",
+                "position": (3, 3),
+                "therapeutic_principle": "Mindfulness"
+            },
+            {
+                "name": "Values Action",
+                "description": "[UNICODE_4FA1]",
+                "daily_reminder": "[UNICODE_5927]",
+                "position": (5, 5),
+                "therapeutic_principle": "Values-Based Action"
+            },
+            {
+                "name": "Acceptance",
+                "description": "[UNICODE_53D7]",
+                "daily_reminder": "[UNICODE_5909]",
+                "position": (3, 5),
+                "therapeutic_principle": "Radical Acceptance"
+            },
+            {
+                "name": "Commitment",
+                "description": "[UNICODE_30B3]",
+                "daily_reminder": "[UNICODE_5927]",
+                "position": (5, 3),
+                "therapeutic_principle": "Psychological Flexibility"
+            }
+        ]
+        
+        for value_data in core_values_data:
+            core_value = CoreValue(**value_data)
+            self.core_values[core_value.position] = core_value
+            
+            # [UNICODE_30B0]
+            x, y = core_value.position
+            value_cell = MemoryCell(
+                cell_id=f"core_value_{x}_{y}",
+                position=(x, y),
+                status=CellStatus.CORE_VALUE,
+                quest_title=core_value.name,
+                quest_description=core_value.description,
+                xp_reward=0,
+                difficulty=0,
+                therapeutic_focus=core_value.therapeutic_principle
+            )
+            self.grid[x][y] = value_cell
+    
+    def unlock_cell(self, x: int, y: int, quest_data: Dict[str, Any]) -> bool:
+        """
+        [UNICODE_30BB]
+        
+        Args:
+            x, y: [UNICODE_30B0]
+            quest_data: [UNICODE_30AF]
+            
+        Returns:
+            bool: [UNICODE_30A2]/[UNICODE_5931]
+        """
+        if not self._is_valid_position(x, y):
             return False
         
-        # アンロック条件チェック
-        for condition in self.unlock_conditions:
-            if condition not in completed_cells:
-                return False
+        if not self.can_unlock(x, y):
+            return False
+        
+        # [UNICODE_65E2]
+        if (x, y) in self.core_values:
+            return False
+        
+        # [UNICODE_30E1]
+        memory_cell = MemoryCell(
+            cell_id=quest_data.get("cell_id", f"cell_{x}_{y}"),
+            position=(x, y),
+            status=CellStatus.UNLOCKED,
+            quest_title=quest_data.get("quest_title", ""),
+            quest_description=quest_data.get("quest_description", ""),
+            xp_reward=quest_data.get("xp_reward", 10),
+            difficulty=quest_data.get("difficulty", 1),
+            unlock_requirements=quest_data.get("unlock_requirements", []),
+            linked_story_node=quest_data.get("linked_story_node"),
+            therapeutic_focus=quest_data.get("therapeutic_focus")
+        )
+        
+        self.grid[x][y] = memory_cell
+        self.unlocked_count += 1
+        self.last_updated = datetime.now()
         
         return True
-
-
-class MandalaGrid(BaseModel):
-    """9x9 Mandalaグリッド"""
-    chapter_type: ChapterType
-    cells: List[List[Optional[MemoryCell]]] = []  # 9x9グリッド
-    center_value: str = ""
-    completion_percentage: float = 0.0
-    unlocked_count: int = 0
-    completed_count: int = 0
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
     
-    def __init__(self, **data):
-        super().__init__(**data)
-        if not self.cells:
-            self._initialize_grid()
-        self._update_statistics()
-    
-    def _initialize_grid(self):
-        """グリッド初期化"""
-        self.cells = [[None for _ in range(9)] for _ in range(9)]
+    def complete_cell(self, x: int, y: int) -> bool:
+        """
+        [UNICODE_30BB]
         
-        # 中央価値設定
-        center_values = {
-            ChapterType.SELF_DISCIPLINE: "自律性",
-            ChapterType.EMPATHY: "共感力",
-            ChapterType.RESILIENCE: "回復力",
-            ChapterType.CURIOSITY: "好奇心",
-            ChapterType.COMMUNICATION: "コミュニケーション",
-            ChapterType.CREATIVITY: "創造性",
-            ChapterType.COURAGE: "勇気",
-            ChapterType.WISDOM: "知恵"
-        }
-        self.center_value = center_values.get(self.chapter_type, "成長")
-        
-        # セル初期化
-        for row in range(9):
-            for col in range(9):
-                cell = MemoryCell(
-                    position=(row, col),
-                    chapter_type=self.chapter_type,
-                    title=self._generate_cell_title(row, col),
-                    description=self._generate_cell_description(row, col),
-                    unlock_conditions=self._generate_unlock_conditions(row, col)
-                )
-                
-                # 中央セルは最初からアンロック
-                if cell.is_center_cell():
-                    cell.status = CellStatus.AVAILABLE
-                
-                self.cells[row][col] = cell
-    
-    def _generate_cell_title(self, row: int, col: int) -> str:
-        """セルタイトル生成"""
-        if (row, col) == (4, 4):
-            return f"{self.center_value}の核心"
-        
-        # 章タイプに基づくタイトル生成
-        chapter_titles = {
-            ChapterType.SELF_DISCIPLINE: [
-                "朝の習慣", "時間管理", "目標設定", "集中力", "継続力",
-                "自制心", "規律", "責任感", "計画性"
-            ],
-            ChapterType.EMPATHY: [
-                "他者理解", "感情認識", "共感表現", "傾聴", "思いやり",
-                "配慮", "支援", "協調", "理解"
-            ],
-            # 他の章タイプも同様に定義
-        }
-        
-        titles = chapter_titles.get(self.chapter_type, ["成長", "発見", "学び"])
-        index = (row * 9 + col) % len(titles)
-        return titles[index]
-    
-    def _generate_cell_description(self, row: int, col: int) -> str:
-        """セル説明生成"""
-        if (row, col) == (4, 4):
-            return f"{self.center_value}の本質を理解し、実践する"
-        
-        return f"{self._generate_cell_title(row, col)}に関する課題や活動"
-    
-    def _generate_unlock_conditions(self, row: int, col: int) -> List[str]:
-        """アンロック条件生成"""
-        if (row, col) == (4, 4):
-            return []  # 中央は条件なし
-        
-        conditions = []
-        
-        # 中央から近い順にアンロック
-        distance = max(abs(row - 4), abs(col - 4))
-        
-        if distance == 1:
-            # 中央周辺は中央完了が条件
-            conditions.append("center_completed")
-        elif distance == 2:
-            # 2層目は1層目の隣接セル完了が条件
-            adjacent_positions = self._get_adjacent_positions(row, col, distance - 1)
-            for pos in adjacent_positions:
-                conditions.append(f"cell_{pos[0]}_{pos[1]}_completed")
-        
-        return conditions
-    
-    def _get_adjacent_positions(self, row: int, col: int, target_distance: int) -> List[Tuple[int, int]]:
-        """指定距離の隣接位置取得"""
-        positions = []
-        for r in range(max(0, row - 1), min(9, row + 2)):
-            for c in range(max(0, col - 1), min(9, col + 2)):
-                if (r, c) != (row, col):
-                    distance = max(abs(r - 4), abs(c - 4))
-                    if distance == target_distance:
-                        positions.append((r, c))
-        return positions
-    
-    def unlock_cell(self, row: int, col: int) -> bool:
-        """セルアンロック"""
-        if not (0 <= row < 9 and 0 <= col < 9):
+        Args:
+            x, y: [UNICODE_30B0]
+            
+        Returns:
+            bool: [UNICODE_5B8C]/[UNICODE_5931]
+        """
+        if not self._is_valid_position(x, y):
             return False
         
-        cell = self.cells[row][col]
-        if not cell or cell.status != CellStatus.LOCKED:
-            return False
-        
-        # アンロック条件チェック
-        completed_cells = self._get_completed_cell_ids()
-        if not cell.can_unlock(completed_cells):
-            return False
-        
-        cell.status = CellStatus.AVAILABLE
-        self.last_updated = datetime.utcnow()
-        self._update_statistics()
-        
-        return True
-    
-    def complete_cell(self, row: int, col: int, task_id: Optional[str] = None) -> bool:
-        """セル完了"""
-        if not (0 <= row < 9 and 0 <= col < 9):
-            return False
-        
-        cell = self.cells[row][col]
-        if not cell or cell.status != CellStatus.AVAILABLE:
+        cell = self.grid[x][y]
+        if not cell or cell.status != CellStatus.UNLOCKED:
             return False
         
         cell.status = CellStatus.COMPLETED
-        cell.completion_date = datetime.utcnow()
-        cell.task_id = task_id
-        
-        # 隣接セルのアンロックチェック
-        self._check_adjacent_unlocks(row, col)
-        
-        self.last_updated = datetime.utcnow()
-        self._update_statistics()
+        cell.completion_time = datetime.now()
+        self.last_updated = datetime.now()
         
         return True
     
-    def _check_adjacent_unlocks(self, row: int, col: int):
-        """隣接セルのアンロック可能性チェック"""
-        for r in range(max(0, row - 2), min(9, row + 3)):
-            for c in range(max(0, col - 2), min(9, col + 3)):
-                if (r, c) != (row, col):
-                    self.unlock_cell(r, c)
-    
-    def _get_completed_cell_ids(self) -> List[str]:
-        """完了済みセルID一覧取得"""
-        completed = []
-        
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell and cell.status == CellStatus.COMPLETED:
-                    completed.append(f"cell_{row}_{col}_completed")
-        
-        # 中央セル特別処理
-        center_cell = self.cells[4][4]
-        if center_cell and center_cell.status == CellStatus.COMPLETED:
-            completed.append("center_completed")
-        
-        return completed
-    
-    def _update_statistics(self):
-        """統計更新"""
-        total_cells = 81
-        unlocked = 0
-        completed = 0
-        
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell:
-                    if cell.status in [CellStatus.AVAILABLE, CellStatus.IN_PROGRESS, CellStatus.COMPLETED]:
-                        unlocked += 1
-                    if cell.status == CellStatus.COMPLETED:
-                        completed += 1
-        
-        self.unlocked_count = unlocked
-        self.completed_count = completed
-        self.completion_percentage = (completed / total_cells) * 100
-    
     def get_cell(self, x: int, y: int) -> Optional[MemoryCell]:
-        """指定位置のセル取得"""
-        if not (0 <= x < 9 and 0 <= y < 9):
+        """[UNICODE_6307]"""
+        if not self._is_valid_position(x, y):
             return None
-        return self.cells[x][y]
-    
-    def can_unlock(self, x: int, y: int) -> bool:
-        """指定位置のセルがアンロック可能かチェック"""
-        cell = self.get_cell(x, y)
-        if not cell:
-            return False
-        
-        completed_cells = self._get_completed_cell_ids()
-        return cell.can_unlock(completed_cells)
+        return self.grid[x][y]
     
     def get_unlocked_cells(self) -> List[MemoryCell]:
-        """アンロック済みセル一覧取得"""
-        unlocked = []
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell and cell.status in [CellStatus.AVAILABLE, CellStatus.IN_PROGRESS, CellStatus.COMPLETED]:
-                    unlocked.append(cell)
-        return unlocked
+        """[UNICODE_30A2]"""
+        unlocked_cells = []
+        for row in self.grid:
+            for cell in row:
+                if cell and cell.status == CellStatus.UNLOCKED:
+                    unlocked_cells.append(cell)
+        return unlocked_cells
     
     def get_completed_cells(self) -> List[MemoryCell]:
-        """完了済みセル一覧取得"""
-        completed = []
-        for row in range(9):
-            for col in range(9):
-                cell = self.cells[row][col]
+        """[UNICODE_5B8C]"""
+        completed_cells = []
+        for row in self.grid:
+            for cell in row:
                 if cell and cell.status == CellStatus.COMPLETED:
-                    completed.append(cell)
-        return completed
+                    completed_cells.append(cell)
+        return completed_cells
     
-    @property
-    def total_cells(self) -> int:
-        """総セル数"""
-        return 81
+    def get_daily_core_value_reminder(self) -> str:
+        """[UNICODE_4ECA]"""
+        import random
+        core_values_list = list(self.core_values.values())
+        if core_values_list:
+            selected_value = random.choice(core_values_list)
+            return f"[UNICODE_1F48E] {selected_value.name}: {selected_value.daily_reminder}"
+        return "[UNICODE_1F48E] [UNICODE_4ECA]"
     
-    @property
-    def core_values(self) -> Dict[str, str]:
-        """コア価値一覧"""
-        return {
-            "center": self.center_value,
-            "chapter": self.chapter_type.value
-        }
+    def _is_valid_position(self, x: int, y: int) -> bool:
+        """[UNICODE_5EA7]"""
+        return 0 <= x < 9 and 0 <= y < 9
     
-    def to_api_response(self, uid: str) -> Dict[str, Any]:
-        """API応答形式に変換"""
+    def can_unlock(self, x: int, y: int) -> bool:
+        """[UNICODE_30BB]"""
+        # [UNICODE_65E2]
+        if self.grid[x][y] is not None:
+            return False
+        
+        # [UNICODE_96A3]
+        adjacent_positions = [
+            (x-1, y), (x+1, y), (x, y-1), (x, y+1),
+            (x-1, y-1), (x-1, y+1), (x+1, y-1), (x+1, y+1)
+        ]
+        
+        for adj_x, adj_y in adjacent_positions:
+            if self._is_valid_position(adj_x, adj_y):
+                adj_cell = self.grid[adj_x][adj_y]
+                if adj_cell and adj_cell.status in [CellStatus.UNLOCKED, CellStatus.COMPLETED, CellStatus.CORE_VALUE]:
+                    return True
+        
+        return False
+    
+    def serialize_grid(self) -> Dict[str, Any]:
+        """[UNICODE_30B0]JSON[UNICODE_5F62]"""
         grid_data = []
         
-        for row in range(9):
-            row_data = []
-            for col in range(9):
-                cell = self.cells[row][col]
-                if cell:
+        for x in range(9):
+            row = []
+            for y in range(9):
+                cell = self.grid[x][y]
+                if cell is None:
+                    row.append({"status": "locked"})
+                else:
                     cell_data = {
-                        "id": cell.cell_id,
+                        "cell_id": cell.cell_id,
                         "position": cell.position,
                         "status": cell.status.value,
-                        "title": cell.title,
-                        "description": cell.description,
+                        "quest_title": cell.quest_title,
+                        "quest_description": cell.quest_description,
                         "xp_reward": cell.xp_reward,
-                        "task_id": cell.task_id,
-                        "completion_date": cell.completion_date.isoformat() if cell.completion_date else None
+                        "difficulty": cell.difficulty,
+                        "therapeutic_focus": cell.therapeutic_focus
                     }
-                else:
-                    cell_data = {"status": "locked"}
-                
-                row_data.append(cell_data)
-            grid_data.append(row_data)
+                    
+                    if cell.completion_time:
+                        cell_data["completion_time"] = cell.completion_time.isoformat()
+                    
+                    if cell.linked_story_node:
+                        cell_data["linked_story_node"] = cell.linked_story_node
+                    
+                    row.append(cell_data)
+            grid_data.append(row)
         
         return {
-            "uid": uid,
-            "chapter_type": self.chapter_type.value,
-            "center_value": self.center_value,
+            "uid": self.uid,
             "grid": grid_data,
             "unlocked_count": self.unlocked_count,
-            "completed_count": self.completed_count,
-            "completion_percentage": self.completion_percentage,
-            "total_cells": 81,
-            "core_values": self.core_values,
-            "last_updated": self.last_updated.isoformat()
+            "total_cells": self.total_cells,
+            "completion_rate": self.unlocked_count / self.total_cells if self.total_cells > 0 else 0,
+            "last_updated": self.last_updated.isoformat(),
+            "core_values": {
+                f"{pos[0]}_{pos[1]}": {
+                    "name": value.name,
+                    "description": value.description,
+                    "daily_reminder": value.daily_reminder,
+                    "therapeutic_principle": value.therapeutic_principle
+                }
+                for pos, value in self.core_values.items()
+            }
         }
+    
+    @classmethod
+    def deserialize_grid(cls, data: Dict[str, Any]) -> 'MandalaGrid':
+        """JSON[UNICODE_5F62]"""
+        mandala = cls(data["uid"])
+        mandala.unlocked_count = data.get("unlocked_count", 0)
+        mandala.last_updated = datetime.fromisoformat(data.get("last_updated", datetime.now().isoformat()))
+        
+        grid_data = data.get("grid", [])
+        for x in range(9):
+            for y in range(9):
+                if x < len(grid_data) and y < len(grid_data[x]):
+                    cell_data = grid_data[x][y]
+                    if cell_data.get("status") != "locked":
+                        cell = MemoryCell(
+                            cell_id=cell_data.get("cell_id", f"cell_{x}_{y}"),
+                            position=(x, y),
+                            status=CellStatus(cell_data.get("status", "locked")),
+                            quest_title=cell_data.get("quest_title", ""),
+                            quest_description=cell_data.get("quest_description", ""),
+                            xp_reward=cell_data.get("xp_reward", 0),
+                            difficulty=cell_data.get("difficulty", 1),
+                            therapeutic_focus=cell_data.get("therapeutic_focus")
+                        )
+                        
+                        if cell_data.get("completion_time"):
+                            cell.completion_time = datetime.fromisoformat(cell_data["completion_time"])
+                        
+                        if cell_data.get("linked_story_node"):
+                            cell.linked_story_node = cell_data["linked_story_node"]
+                        
+                        mandala.grid[x][y] = cell
+        
+        return mandala
 
 
 class MandalaSystemInterface:
-    """Mandalaシステムインターフェース"""
+    """Mandala[UNICODE_30B7]"""
     
     def __init__(self):
-        # 実際の実装ではFirestoreを使用
-        self.user_grids: Dict[str, Dict[ChapterType, MandalaGrid]] = {}
+        self.grids: Dict[str, MandalaGrid] = {}
     
-    def get_user_grid(self, uid: str, chapter_type: ChapterType) -> MandalaGrid:
-        """ユーザーのMandalaグリッド取得"""
-        if uid not in self.user_grids:
-            self.user_grids[uid] = {}
-        
-        if chapter_type not in self.user_grids[uid]:
-            self.user_grids[uid][chapter_type] = MandalaGrid(chapter_type=chapter_type)
-        
-        return self.user_grids[uid][chapter_type]
+    def get_or_create_grid(self, uid: str) -> MandalaGrid:
+        """[UNICODE_30E6]Mandala[UNICODE_30B0]"""
+        if uid not in self.grids:
+            self.grids[uid] = MandalaGrid(uid)
+        return self.grids[uid]
     
-    def unlock_cell(self, uid: str, chapter_type: ChapterType, row: int, col: int) -> bool:
-        """セルアンロック"""
-        grid = self.get_user_grid(uid, chapter_type)
-        return grid.unlock_cell(row, col)
-    
-    def complete_cell(
-        self, 
-        uid: str, 
-        chapter_type: ChapterType, 
-        row: int, 
-        col: int,
-        task_id: Optional[str] = None
-    ) -> bool:
-        """セル完了"""
-        grid = self.get_user_grid(uid, chapter_type)
-        return grid.complete_cell(row, col, task_id)
-    
-    def get_grid_api_response(self, uid: str, chapter_type: ChapterType) -> Dict[str, Any]:
-        """グリッドAPI応答取得"""
-        grid = self.get_user_grid(uid, chapter_type)
-        return grid.to_api_response(uid)
-    
-    def get_user_progress_summary(self, uid: str) -> Dict[str, Any]:
-        """ユーザー進捗サマリー取得"""
-        if uid not in self.user_grids:
-            return {
-                "uid": uid,
-                "total_chapters": 0,
-                "completed_chapters": 0,
-                "total_cells": 0,
-                "completed_cells": 0,
-                "overall_completion": 0.0,
-                "chapter_progress": {}
-            }
-        
-        total_cells = 0
-        completed_cells = 0
-        completed_chapters = 0
-        chapter_progress = {}
-        
-        for chapter_type, grid in self.user_grids[uid].items():
-            total_cells += 81
-            completed_cells += grid.completed_count
-            
-            chapter_progress[chapter_type.value] = {
-                "completion_percentage": grid.completion_percentage,
-                "completed_count": grid.completed_count,
-                "unlocked_count": grid.unlocked_count
-            }
-            
-            if grid.completion_percentage >= 100.0:
-                completed_chapters += 1
-        
-        overall_completion = (completed_cells / total_cells * 100) if total_cells > 0 else 0.0
-        
-        return {
-            "uid": uid,
-            "total_chapters": len(self.user_grids[uid]),
-            "completed_chapters": completed_chapters,
-            "total_cells": total_cells,
-            "completed_cells": completed_cells,
-            "overall_completion": overall_completion,
-            "chapter_progress": chapter_progress
-        }
-    
-    # 統合テスト用の互換性メソッド
-    def get_or_create_grid(self, uid: str, chapter_type: ChapterType = ChapterType.SELF_DISCIPLINE) -> MandalaGrid:
-        """グリッド取得または作成（統合テスト用）"""
-        return self.get_user_grid(uid, chapter_type)
+    def get_grid_api_response(self, uid: str) -> Dict[str, Any]:
+        """API[UNICODE_5FDC]"""
+        grid = self.get_or_create_grid(uid)
+        return grid.serialize_grid()
     
     def unlock_cell_for_user(self, uid: str, x: int, y: int, quest_data: Dict[str, Any]) -> bool:
-        """ユーザー用セルアンロック（統合テスト用）"""
-        # デフォルトのchapter_typeを使用
-        return self.unlock_cell(uid, ChapterType.SELF_DISCIPLINE, x, y)
+        """[UNICODE_30E6]"""
+        grid = self.get_or_create_grid(uid)
+        return grid.unlock_cell(x, y, quest_data)
     
     def complete_cell_for_user(self, uid: str, x: int, y: int) -> bool:
-        """ユーザー用セル完了（統合テスト用）"""
-        # デフォルトのchapter_typeを使用
-        return self.complete_cell(uid, ChapterType.SELF_DISCIPLINE, x, y)
+        """[UNICODE_30E6]"""
+        grid = self.get_or_create_grid(uid)
+        return grid.complete_cell(x, y)
     
     def get_daily_reminder_for_user(self, uid: str) -> str:
-        """ユーザー用日次リマインダー取得（統合テスト用）"""
-        return f"{uid}さん、今日もMandalaで成長の一歩を踏み出しましょう！"
+        """[UNICODE_30E6]"""
+        grid = self.get_or_create_grid(uid)
+        return grid.get_daily_core_value_reminder()
+    
+    def save_grid(self, uid: str) -> Dict[str, Any]:
+        """[UNICODE_30B0]"""
+        if uid in self.grids:
+            return self.grids[uid].serialize_grid()
+        return {}
+    
+    def load_grid(self, uid: str, data: Dict[str, Any]) -> None:
+        """[UNICODE_4FDD]"""
+        self.grids[uid] = MandalaGrid.deserialize_grid(data)

--- a/shared/interfaces/mandala_validation.py
+++ b/shared/interfaces/mandala_validation.py
@@ -1,390 +1,365 @@
 """
-Mandala Validation Interface
+Mandala System Validation
 
-Mandalaシステムのバリデーション機能
+Mandala[UNICODE_30B7]
+
 Requirements: 4.1, 4.3
 """
 
-from typing import Dict, List, Optional, Tuple, Any
-from .core_types import ChapterType, CellStatus
-from .validation import ValidationResult, BaseValidator
+from typing import Dict, List, Any, Tuple, Optional
+from dataclasses import dataclass
+from .mandala_system import MandalaGrid, MemoryCell, CellStatus
 
 
-class MandalaValidator(BaseValidator):
-    """Mandalaバリデーター"""
+@dataclass
+class ValidationResult:
+    """[UNICODE_691C]"""
+    is_valid: bool
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+    warnings: List[str] = None
     
-    @classmethod
-    def validate_grid_position(cls, row: int, col: int) -> ValidationResult:
-        """グリッド位置バリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        if not isinstance(row, int) or not isinstance(col, int):
-            result.add_error("行と列は整数である必要があります")
-            return result
-        
-        if not (0 <= row <= 8):
-            result.add_error("行は0-8の範囲である必要があります", "row")
-        
-        if not (0 <= col <= 8):
-            result.add_error("列は0-8の範囲である必要があります", "col")
-        
-        result.is_valid = len(result.errors) == 0
-        return result
+    def __post_init__(self):
+        if self.warnings is None:
+            self.warnings = []
+
+
+class MandalaValidator:
+    """Mandala[UNICODE_30B7]"""
     
-    @classmethod
-    def validate_chapter_type(cls, chapter_type: str) -> ValidationResult:
-        """チャプタータイプバリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        try:
-            ChapterType(chapter_type)
-        except ValueError:
-            result.add_error("無効なチャプタータイプです", "chapter_type")
-        
-        result.is_valid = len(result.errors) == 0
-        return result
+    def __init__(self):
+        self.max_difficulty = 5
+        self.min_difficulty = 1
+        self.max_xp_reward = 1000
+        self.min_xp_reward = 1
+        self.max_quest_title_length = 100
+        self.max_quest_description_length = 500
     
-    @classmethod
-    def validate_cell_unlock_request(cls, unlock_data: Dict[str, Any]) -> ValidationResult:
-        """セルアンロックリクエストバリデーション"""
-        result = ValidationResult(is_valid=True)
+    def validate_grid_structure(self, grid: MandalaGrid) -> ValidationResult:
+        """[UNICODE_30B0]"""
+        errors = []
+        warnings = []
         
-        # 必須フィールドチェック
-        required_fields = ["uid", "chapter_type", "row", "col"]
+        # [UNICODE_30B0]
+        if len(grid.grid) != 9:
+            errors.append("[UNICODE_30B0]9[UNICODE_3067]")
+        
+        for i, row in enumerate(grid.grid):
+            if len(row) != 9:
+                errors.append(f"[UNICODE_30B0]{i}[UNICODE_306E]9[UNICODE_3067]")
+        
+        # [UNICODE_4E2D]
+        core_value_positions = [(4, 4), (3, 4), (5, 4), (4, 3), (4, 5), (3, 3), (5, 5), (3, 5), (5, 3)]
+        for pos in core_value_positions:
+            x, y = pos
+            cell = grid.grid[x][y]
+            if not cell or cell.status != CellStatus.CORE_VALUE:
+                errors.append(f"[UNICODE_4E2D]({x}, {y})[UNICODE_304C]")
+        
+        # [UNICODE_30A2]
+        actual_unlocked = sum(1 for row in grid.grid for cell in row 
+                            if cell and cell.status in [CellStatus.UNLOCKED, CellStatus.COMPLETED])
+        if actual_unlocked != grid.unlocked_count:
+            warnings.append(f"[UNICODE_30A2]: [UNICODE_5B9F]={actual_unlocked}, [UNICODE_8A18]={grid.unlocked_count}")
+        
+        if errors:
+            return ValidationResult(
+                is_valid=False,
+                error_code="GRID_STRUCTURE_INVALID",
+                error_message="; ".join(errors),
+                warnings=warnings
+            )
+        
+        return ValidationResult(is_valid=True, warnings=warnings)
+    
+    def validate_cell_data(self, cell: MemoryCell) -> ValidationResult:
+        """[UNICODE_30BB]"""
+        errors = []
+        warnings = []
+        
+        # [UNICODE_5EA7]
+        x, y = cell.position
+        if not (0 <= x < 9 and 0 <= y < 9):
+            errors.append(f"[UNICODE_7121]: ({x}, {y})")
+        
+        # [UNICODE_96E3]
+        if not (self.min_difficulty <= cell.difficulty <= self.max_difficulty):
+            errors.append(f"[UNICODE_96E3]: {cell.difficulty} ([UNICODE_7BC4]: {self.min_difficulty}-{self.max_difficulty})")
+        
+        # XP[UNICODE_5831]
+        if not (self.min_xp_reward <= cell.xp_reward <= self.max_xp_reward):
+            errors.append(f"XP[UNICODE_5831]: {cell.xp_reward} ([UNICODE_7BC4]: {self.min_xp_reward}-{self.max_xp_reward})")
+        
+        # [UNICODE_30AF]
+        if not cell.quest_title or len(cell.quest_title.strip()) == 0:
+            errors.append("[UNICODE_30AF]")
+        elif len(cell.quest_title) > self.max_quest_title_length:
+            errors.append(f"[UNICODE_30AF]: {len(cell.quest_title)} > {self.max_quest_title_length}")
+        
+        # [UNICODE_30AF]
+        if not cell.quest_description or len(cell.quest_description.strip()) == 0:
+            warnings.append("[UNICODE_30AF]")
+        elif len(cell.quest_description) > self.max_quest_description_length:
+            errors.append(f"[UNICODE_30AF]: {len(cell.quest_description)} > {self.max_quest_description_length}")
+        
+        # [UNICODE_30BB]ID[UNICODE_306E]
+        if not cell.cell_id or len(cell.cell_id.strip()) == 0:
+            errors.append("[UNICODE_30BB]ID[UNICODE_304C]")
+        
+        if errors:
+            return ValidationResult(
+                is_valid=False,
+                error_code="CELL_DATA_INVALID",
+                error_message="; ".join(errors),
+                warnings=warnings
+            )
+        
+        return ValidationResult(is_valid=True, warnings=warnings)
+    
+    def validate_unlock_request(self, grid: MandalaGrid, x: int, y: int, 
+                              quest_data: Dict[str, Any]) -> ValidationResult:
+        """[UNICODE_30BB]"""
+        errors = []
+        warnings = []
+        
+        # [UNICODE_5EA7]
+        if not (0 <= x < 9 and 0 <= y < 9):
+            errors.append(f"[UNICODE_7121]: ({x}, {y})")
+            return ValidationResult(
+                is_valid=False,
+                error_code="INVALID_COORDINATES",
+                error_message=errors[0]
+            )
+        
+        # [UNICODE_65E2]
+        existing_cell = grid.grid[x][y]
+        if existing_cell is not None:
+            if existing_cell.status == CellStatus.CORE_VALUE:
+                errors.append("[UNICODE_4E2D]")
+            else:
+                errors.append("[UNICODE_65E2]")
+        
+        # [UNICODE_30A2]
+        if not grid.can_unlock(x, y):
+            errors.append("[UNICODE_30A2]")
+        
+        # [UNICODE_30AF]
+        required_fields = ["quest_title", "quest_description", "xp_reward", "difficulty"]
         for field in required_fields:
-            if field not in unlock_data:
-                result.add_error(f"{field}は必須です", field)
+            if field not in quest_data:
+                errors.append(f"[UNICODE_5FC5]: {field}")
         
-        # 位置バリデーション
-        if "row" in unlock_data and "col" in unlock_data:
-            position_result = cls.validate_grid_position(
-                unlock_data["row"], unlock_data["col"]
+        # [UNICODE_96E3]
+        difficulty = quest_data.get("difficulty", 0)
+        if not isinstance(difficulty, int) or not (self.min_difficulty <= difficulty <= self.max_difficulty):
+            errors.append(f"[UNICODE_7121]: {difficulty}")
+        
+        # XP[UNICODE_5831]
+        xp_reward = quest_data.get("xp_reward", 0)
+        if not isinstance(xp_reward, int) or not (self.min_xp_reward <= xp_reward <= self.max_xp_reward):
+            errors.append(f"[UNICODE_7121]XP[UNICODE_5831]: {xp_reward}")
+        
+        if errors:
+            return ValidationResult(
+                is_valid=False,
+                error_code="UNLOCK_REQUEST_INVALID",
+                error_message="; ".join(errors),
+                warnings=warnings
             )
-            if not position_result.is_valid:
-                result.errors.extend(position_result.errors)
-                result.field_errors.update(position_result.field_errors)
         
-        # チャプタータイプバリデーション
-        if "chapter_type" in unlock_data:
-            chapter_result = cls.validate_chapter_type(unlock_data["chapter_type"])
-            if not chapter_result.is_valid:
-                result.errors.extend(chapter_result.errors)
-                result.field_errors.update(chapter_result.field_errors)
-        
-        # UIDバリデーション
-        if "uid" in unlock_data:
-            uid_result = cls.validate_string_length(
-                unlock_data["uid"], "uid", min_length=1, max_length=50
-            )
-            if not uid_result.is_valid:
-                result.errors.extend(uid_result.errors)
-                result.field_errors.update(uid_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
+        return ValidationResult(is_valid=True, warnings=warnings)
     
-    @classmethod
-    def validate_cell_completion_request(cls, completion_data: Dict[str, Any]) -> ValidationResult:
-        """セル完了リクエストバリデーション"""
-        result = ValidationResult(is_valid=True)
+    def validate_completion_request(self, grid: MandalaGrid, x: int, y: int) -> ValidationResult:
+        """[UNICODE_30BB]"""
+        errors = []
         
-        # 基本的なアンロックリクエストバリデーション
-        unlock_result = cls.validate_cell_unlock_request(completion_data)
-        if not unlock_result.is_valid:
-            result.errors.extend(unlock_result.errors)
-            result.field_errors.update(unlock_result.field_errors)
-        
-        # タスクIDバリデーション（オプション）
-        if "task_id" in completion_data and completion_data["task_id"]:
-            task_id_result = cls.validate_string_length(
-                completion_data["task_id"], "task_id", min_length=1, max_length=100
+        # [UNICODE_5EA7]
+        if not (0 <= x < 9 and 0 <= y < 9):
+            errors.append(f"[UNICODE_7121]: ({x}, {y})")
+            return ValidationResult(
+                is_valid=False,
+                error_code="INVALID_COORDINATES",
+                error_message=errors[0]
             )
-            if not task_id_result.is_valid:
-                result.errors.extend(task_id_result.errors)
-                result.field_errors.update(task_id_result.field_errors)
         
-        result.is_valid = len(result.errors) == 0
-        return result
-    
-    @classmethod
-    def validate_mandala_grid_data(cls, grid_data: Dict[str, Any]) -> ValidationResult:
-        """Mandalaグリッドデータバリデーション"""
-        result = ValidationResult(is_valid=True)
+        # [UNICODE_30BB]
+        cell = grid.grid[x][y]
+        if cell is None:
+            errors.append("[UNICODE_30BB]")
+        elif cell.status != CellStatus.UNLOCKED:
+            if cell.status == CellStatus.LOCKED:
+                errors.append("[UNICODE_30ED]")
+            elif cell.status == CellStatus.COMPLETED:
+                errors.append("[UNICODE_65E2]")
+            elif cell.status == CellStatus.CORE_VALUE:
+                errors.append("[UNICODE_4E2D]")
         
-        # 必須フィールドチェック
-        required_fields = ["chapter_type", "cells"]
-        for field in required_fields:
-            if field not in grid_data:
-                result.add_error(f"{field}は必須です", field)
-        
-        # チャプタータイプバリデーション
-        if "chapter_type" in grid_data:
-            chapter_result = cls.validate_chapter_type(grid_data["chapter_type"])
-            if not chapter_result.is_valid:
-                result.errors.extend(chapter_result.errors)
-                result.field_errors.update(chapter_result.field_errors)
-        
-        # セルデータバリデーション
-        if "cells" in grid_data:
-            cells_result = cls._validate_cells_data(grid_data["cells"])
-            if not cells_result.is_valid:
-                result.errors.extend(cells_result.errors)
-                result.field_errors.update(cells_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
-    
-    @classmethod
-    def _validate_cells_data(cls, cells_data: Any) -> ValidationResult:
-        """セルデータバリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        # リスト形式チェック
-        if not isinstance(cells_data, list):
-            result.add_error("cellsはリストである必要があります", "cells")
-            return result
-        
-        # 9x9グリッドチェック
-        if len(cells_data) != 9:
-            result.add_error("cellsは9行である必要があります", "cells")
-            return result
-        
-        for row_idx, row_data in enumerate(cells_data):
-            if not isinstance(row_data, list):
-                result.add_error(f"行{row_idx}はリストである必要があります", f"cells[{row_idx}]")
-                continue
-            
-            if len(row_data) != 9:
-                result.add_error(f"行{row_idx}は9列である必要があります", f"cells[{row_idx}]")
-                continue
-            
-            for col_idx, cell_data in enumerate(row_data):
-                if cell_data is not None:
-                    cell_result = cls._validate_single_cell_data(cell_data, row_idx, col_idx)
-                    if not cell_result.is_valid:
-                        result.errors.extend(cell_result.errors)
-                        result.field_errors.update(cell_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
-    
-    @classmethod
-    def _validate_single_cell_data(cls, cell_data: Dict[str, Any], row: int, col: int) -> ValidationResult:
-        """単一セルデータバリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        cell_prefix = f"cells[{row}][{col}]"
-        
-        # 必須フィールドチェック
-        required_fields = ["position", "status"]
-        for field in required_fields:
-            if field not in cell_data:
-                result.add_error(f"{field}は必須です", f"{cell_prefix}.{field}")
-        
-        # 位置チェック
-        if "position" in cell_data:
-            position = cell_data["position"]
-            if not isinstance(position, (list, tuple)) or len(position) != 2:
-                result.add_error("positionは[row, col]形式である必要があります", f"{cell_prefix}.position")
-            elif position != (row, col):
-                result.add_error(f"位置が一致しません。期待値: ({row}, {col}), 実際: {position}", f"{cell_prefix}.position")
-        
-        # ステータスチェック
-        if "status" in cell_data:
-            try:
-                CellStatus(cell_data["status"])
-            except ValueError:
-                result.add_error("無効なセルステータスです", f"{cell_prefix}.status")
-        
-        # オプションフィールドバリデーション
-        if "title" in cell_data and cell_data["title"]:
-            title_result = cls.validate_string_length(
-                cell_data["title"], f"{cell_prefix}.title", max_length=100
+        if errors:
+            return ValidationResult(
+                is_valid=False,
+                error_code="COMPLETION_REQUEST_INVALID",
+                error_message="; ".join(errors)
             )
-            if not title_result.is_valid:
-                result.errors.extend(title_result.errors)
-                result.field_errors.update(title_result.field_errors)
         
-        if "description" in cell_data and cell_data["description"]:
-            desc_result = cls.validate_string_length(
-                cell_data["description"], f"{cell_prefix}.description", max_length=500
-            )
-            if not desc_result.is_valid:
-                result.errors.extend(desc_result.errors)
-                result.field_errors.update(desc_result.field_errors)
-        
-        if "xp_reward" in cell_data:
-            xp_result = cls.validate_numeric_range(
-                cell_data["xp_reward"], f"{cell_prefix}.xp_reward", min_value=0, max_value=1000
-            )
-            if not xp_result.is_valid:
-                result.errors.extend(xp_result.errors)
-                result.field_errors.update(xp_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
+        return ValidationResult(is_valid=True)
     
-    @classmethod
-    def validate_progress_summary_request(cls, request_data: Dict[str, Any]) -> ValidationResult:
-        """進捗サマリーリクエストバリデーション"""
-        result = ValidationResult(is_valid=True)
+    def validate_api_response_data(self, data: Dict[str, Any]) -> ValidationResult:
+        """API[UNICODE_5FDC]"""
+        errors = []
+        warnings = []
         
-        # UIDチェック
-        if "uid" not in request_data:
-            result.add_error("uidは必須です", "uid")
-        else:
-            uid_result = cls.validate_string_length(
-                request_data["uid"], "uid", min_length=1, max_length=50
-            )
-            if not uid_result.is_valid:
-                result.errors.extend(uid_result.errors)
-                result.field_errors.update(uid_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
-    
-    @classmethod
-    def validate_api_response_data(cls, response_data: Dict[str, Any]) -> ValidationResult:
-        """API応答データバリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        # 必須フィールドチェック
+        # [UNICODE_5FC5]
         required_fields = ["uid", "grid", "unlocked_count", "total_cells"]
         for field in required_fields:
-            if field not in response_data:
-                result.add_error(f"{field}は必須です", field)
+            if field not in data:
+                errors.append(f"[UNICODE_5FC5]: {field}")
         
-        # UIDバリデーション
-        if "uid" in response_data:
-            uid_result = cls.validate_string_length(
-                response_data["uid"], "uid", min_length=1, max_length=50
+        # [UNICODE_30B0]
+        if "grid" in data:
+            grid_data = data["grid"]
+            if not isinstance(grid_data, list) or len(grid_data) != 9:
+                errors.append("[UNICODE_30B0]")
+            else:
+                for i, row in enumerate(grid_data):
+                    if not isinstance(row, list) or len(row) != 9:
+                        errors.append(f"[UNICODE_30B0]{i}[UNICODE_306E]")
+        
+        # [UNICODE_6570]
+        if "unlocked_count" in data:
+            if not isinstance(data["unlocked_count"], int) or data["unlocked_count"] < 0:
+                errors.append("unlocked_count[UNICODE_304C]")
+        
+        if "total_cells" in data:
+            if data["total_cells"] != 81:
+                warnings.append(f"total_cells[UNICODE_304C]: {data['total_cells']} != 81")
+        
+        if errors:
+            return ValidationResult(
+                is_valid=False,
+                error_code="API_RESPONSE_INVALID",
+                error_message="; ".join(errors),
+                warnings=warnings
             )
-            if not uid_result.is_valid:
-                result.errors.extend(uid_result.errors)
-                result.field_errors.update(uid_result.field_errors)
         
-        # グリッドデータバリデーション
-        if "grid" in response_data:
-            grid_result = cls._validate_cells_data(response_data["grid"])
-            if not grid_result.is_valid:
-                result.errors.extend(grid_result.errors)
-                result.field_errors.update(grid_result.field_errors)
-        
-        # 数値フィールドバリデーション
-        numeric_fields = ["unlocked_count", "total_cells", "completed_count"]
-        for field in numeric_fields:
-            if field in response_data:
-                numeric_result = cls.validate_numeric_range(
-                    response_data[field], field, min_value=0, max_value=81
-                )
-                if not numeric_result.is_valid:
-                    result.errors.extend(numeric_result.errors)
-                    result.field_errors.update(numeric_result.field_errors)
-        
-        # 完了率バリデーション
-        if "completion_percentage" in response_data:
-            percentage_result = cls.validate_numeric_range(
-                response_data["completion_percentage"], "completion_percentage", 
-                min_value=0.0, max_value=100.0
-            )
-            if not percentage_result.is_valid:
-                result.errors.extend(percentage_result.errors)
-                result.field_errors.update(percentage_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
+        return ValidationResult(is_valid=True, warnings=warnings)
     
-    @classmethod
-    def validate_unlock_request(cls, grid: Any, x: int, y: int, quest_data: Dict[str, Any]) -> ValidationResult:
-        """アンロックリクエストバリデーション"""
-        result = ValidationResult(is_valid=True)
+    def validate_therapeutic_focus(self, therapeutic_focus: Optional[str]) -> ValidationResult:
+        """[UNICODE_6CBB]"""
+        if not therapeutic_focus:
+            return ValidationResult(is_valid=True)
         
-        # 位置バリデーション
-        position_result = cls.validate_grid_position(x, y)
-        if not position_result.is_valid:
-            result.errors.extend(position_result.errors)
-            result.field_errors.update(position_result.field_errors)
-        
-        # クエストデータバリデーション
-        if "quest_title" in quest_data:
-            title_result = cls.validate_string_length(
-                quest_data["quest_title"], "quest_title", min_length=1, max_length=100
-            )
-            if not title_result.is_valid:
-                result.errors.extend(title_result.errors)
-                result.field_errors.update(title_result.field_errors)
-        
-        if "quest_description" in quest_data:
-            desc_result = cls.validate_string_length(
-                quest_data["quest_description"], "quest_description", min_length=1, max_length=500
-            )
-            if not desc_result.is_valid:
-                result.errors.extend(desc_result.errors)
-                result.field_errors.update(desc_result.field_errors)
-        
-        if "xp_reward" in quest_data:
-            xp_result = cls.validate_numeric_range(
-                quest_data["xp_reward"], "xp_reward", min_value=1, max_value=1000
-            )
-            if not xp_result.is_valid:
-                result.errors.extend(xp_result.errors)
-                result.field_errors.update(xp_result.field_errors)
-        
-        if "difficulty" in quest_data:
-            difficulty_result = cls.validate_numeric_range(
-                quest_data["difficulty"], "difficulty", min_value=1, max_value=5
-            )
-            if not difficulty_result.is_valid:
-                result.errors.extend(difficulty_result.errors)
-                result.field_errors.update(difficulty_result.field_errors)
-        
-        result.is_valid = len(result.errors) == 0
-        return result
-    
-    @classmethod
-    def validate_completion_request(cls, grid: Any, x: int, y: int) -> ValidationResult:
-        """完了リクエストバリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        # 位置バリデーション
-        position_result = cls.validate_grid_position(x, y)
-        if not position_result.is_valid:
-            result.errors.extend(position_result.errors)
-            result.field_errors.update(position_result.field_errors)
-        
-        # グリッドの状態チェック（実装されている場合）
-        if hasattr(grid, 'get_cell'):
-            cell = grid.get_cell(x, y)
-            if cell is None:
-                result.add_error("指定されたセルが存在しません", "cell")
-            elif hasattr(cell, 'status') and cell.status.value != "available":
-                result.add_error("セルが完了可能な状態ではありません", "cell_status")
-        
-        result.is_valid = len(result.errors) == 0
-        return result
-    
-    @classmethod
-    def validate_therapeutic_focus(cls, therapeutic_focus: str) -> ValidationResult:
-        """治療フォーカスバリデーション"""
-        result = ValidationResult(is_valid=True)
-        
-        # 基本的な文字列バリデーション
-        focus_result = cls.validate_string_length(
-            therapeutic_focus, "therapeutic_focus", min_length=1, max_length=100
-        )
-        if not focus_result.is_valid:
-            result.errors.extend(focus_result.errors)
-            result.field_errors.update(focus_result.field_errors)
-        
-        # 許可された治療フォーカス一覧（例）
         valid_focuses = [
-            "self_discipline", "empathy", "resilience", "curiosity",
-            "communication", "creativity", "courage", "wisdom",
-            "mindfulness", "emotional_regulation", "social_skills"
+            "Self-Discipline", "Empathy", "Resilience", "Curiosity",
+            "Communication", "Creativity", "Courage", "Wisdom",
+            "Self-Acceptance", "Self-Compassion", "Growth Mindset",
+            "Authentic Living", "Social Connection", "Mindfulness",
+            "Values-Based Action", "Radical Acceptance", "Psychological Flexibility"
         ]
         
         if therapeutic_focus not in valid_focuses:
-            result.add_warning(f"未知の治療フォーカス: {therapeutic_focus}")
+            return ValidationResult(
+                is_valid=False,
+                error_code="INVALID_THERAPEUTIC_FOCUS",
+                error_message=f"[UNICODE_7121]: {therapeutic_focus}"
+            )
         
-        result.is_valid = len(result.errors) == 0
-        return result
+        return ValidationResult(is_valid=True)
+
+
+class MandalaBusinessRules:
+    """Mandala[UNICODE_30B7]"""
+    
+    def __init__(self):
+        self.max_daily_unlocks = 3  # 1[UNICODE_65E5]3[UNICODE_30BB]
+        self.min_completion_interval_hours = 1  # [UNICODE_30BB]1[UNICODE_6642]
+    
+    def can_unlock_today(self, grid: MandalaGrid, today_unlocks: int) -> ValidationResult:
+        """[UNICODE_4ECA]"""
+        if today_unlocks >= self.max_daily_unlocks:
+            return ValidationResult(
+                is_valid=False,
+                error_code="DAILY_UNLOCK_LIMIT_EXCEEDED",
+                error_message=f"1[UNICODE_65E5]({self.max_daily_unlocks})[UNICODE_306B]"
+            )
+        
+        return ValidationResult(is_valid=True)
+    
+    def can_complete_now(self, grid: MandalaGrid, x: int, y: int, 
+                        last_completion_time: Optional[str]) -> ValidationResult:
+        """[UNICODE_73FE]"""
+        if last_completion_time:
+            from datetime import datetime, timedelta
+            try:
+                last_time = datetime.fromisoformat(last_completion_time)
+                now = datetime.now()
+                if now - last_time < timedelta(hours=self.min_completion_interval_hours):
+                    return ValidationResult(
+                        is_valid=False,
+                        error_code="COMPLETION_INTERVAL_TOO_SHORT",
+                        error_message=f"[UNICODE_524D]{self.min_completion_interval_hours}[UNICODE_6642]"
+                    )
+            except ValueError:
+                pass  # [UNICODE_65E5]
+        
+        return ValidationResult(is_valid=True)
+    
+    def validate_progression_path(self, grid: MandalaGrid) -> ValidationResult:
+        """[UNICODE_9032]"""
+        warnings = []
+        
+        # [UNICODE_5B64]
+        isolated_cells = []
+        for x in range(9):
+            for y in range(9):
+                cell = grid.grid[x][y]
+                if cell and cell.status == CellStatus.UNLOCKED:
+                    if self._is_isolated_cell(grid, x, y):
+                        isolated_cells.append((x, y))
+        
+        if isolated_cells:
+            warnings.append(f"[UNICODE_5B64]: {isolated_cells}")
+        
+        # [UNICODE_30D0]
+        quadrant_counts = self._count_quadrant_unlocks(grid)
+        max_diff = max(quadrant_counts) - min(quadrant_counts)
+        if max_diff > 5:
+            warnings.append(f"[UNICODE_8C61]: {quadrant_counts}")
+        
+        return ValidationResult(is_valid=True, warnings=warnings)
+    
+    def _is_isolated_cell(self, grid: MandalaGrid, x: int, y: int) -> bool:
+        """[UNICODE_30BB]"""
+        adjacent_positions = [
+            (x-1, y), (x+1, y), (x, y-1), (x, y+1),
+            (x-1, y-1), (x-1, y+1), (x+1, y-1), (x+1, y+1)
+        ]
+        
+        connected_count = 0
+        for adj_x, adj_y in adjacent_positions:
+            if 0 <= adj_x < 9 and 0 <= adj_y < 9:
+                adj_cell = grid.grid[adj_x][adj_y]
+                if adj_cell and adj_cell.status in [CellStatus.UNLOCKED, CellStatus.COMPLETED, CellStatus.CORE_VALUE]:
+                    connected_count += 1
+        
+        return connected_count <= 1  # 1[UNICODE_3064]
+    
+    def _count_quadrant_unlocks(self, grid: MandalaGrid) -> List[int]:
+        """[UNICODE_5404]"""
+        quadrants = [
+            [(0, 4), (0, 4)],  # [UNICODE_5DE6]
+            [(0, 4), (5, 8)],  # [UNICODE_53F3]
+            [(5, 8), (0, 4)],  # [UNICODE_5DE6]
+            [(5, 8), (5, 8)]   # [UNICODE_53F3]
+        ]
+        
+        counts = []
+        for (x_range, y_range) in quadrants:
+            count = 0
+            for x in range(x_range[0], x_range[1] + 1):
+                for y in range(y_range[0], y_range[1] + 1):
+                    cell = grid.grid[x][y]
+                    if cell and cell.status in [CellStatus.UNLOCKED, CellStatus.COMPLETED]:
+                        count += 1
+            counts.append(count)
+        
+        return counts

--- a/shared/interfaces/resonance_system.py
+++ b/shared/interfaces/resonance_system.py
@@ -1,37 +1,38 @@
 """
-Resonance System Interface
-
-共鳴イベントシステムのインターフェース定義
+[UNICODE_5171]
+Resonance event system for Player-Yu level synchronization
 Requirements: 4.4, 4.5
 """
 
-from typing import Dict, List, Optional, Tuple, Any
+import math
+import random
+from typing import Dict, List, Optional, Tuple
 from datetime import datetime, timedelta
-from enum import Enum
 from pydantic import BaseModel, Field
-import uuid
-from .core_types import CrystalAttribute
+from enum import Enum
+
+from .core_types import CrystalAttribute, CrystalGrowthEvent
 
 
 class ResonanceType(str, Enum):
-    """共鳴タイプ"""
-    HARMONY = "harmony"           # 調和共鳴
-    GROWTH = "growth"            # 成長共鳴
-    BREAKTHROUGH = "breakthrough" # 突破共鳴
-    WISDOM = "wisdom"            # 知恵共鳴
+    """[UNICODE_5171]"""
+    LEVEL_SYNC = "level_sync"           # [UNICODE_30EC]
+    CRYSTAL_HARMONY = "crystal_harmony" # [UNICODE_30AF]
+    EMOTIONAL_BOND = "emotional_bond"   # [UNICODE_611F]
+    WISDOM_SHARING = "wisdom_sharing"   # [UNICODE_77E5]
 
 
 class ResonanceIntensity(str, Enum):
-    """共鳴強度"""
-    GENTLE = "gentle"     # 穏やか
-    MODERATE = "moderate" # 中程度
-    STRONG = "strong"     # 強い
-    INTENSE = "intense"   # 激しい
+    """[UNICODE_5171]"""
+    WEAK = "weak"         # [UNICODE_5F31]5-7[UNICODE_FF09]
+    MODERATE = "moderate" # [UNICODE_4E2D]8-12[UNICODE_FF09]
+    STRONG = "strong"     # [UNICODE_5F37]13-20[UNICODE_FF09]
+    INTENSE = "intense"   # [UNICODE_6FC0]21[UNICODE_4EE5]
 
 
 class ResonanceEvent(BaseModel):
-    """共鳴イベント"""
-    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    """[UNICODE_5171]"""
+    event_id: str
     resonance_type: ResonanceType
     intensity: ResonanceIntensity
     player_level: int
@@ -40,112 +41,302 @@ class ResonanceEvent(BaseModel):
     bonus_xp: int
     crystal_bonuses: Dict[CrystalAttribute, int] = {}
     special_rewards: List[str] = []
-    therapeutic_message: str = ""
+    therapeutic_message: str
     story_unlock: Optional[str] = None
     triggered_at: datetime = Field(default_factory=datetime.utcnow)
 
 
 class ResonanceCondition(BaseModel):
-    """共鳴発生条件"""
+    """[UNICODE_5171]"""
     min_level_difference: int = 5
-    max_level_difference: int = 20
-    cooldown_hours: int = 24
-    required_player_level: int = 1
+    max_level_difference: int = 50
+    cooldown_hours: int = 24  # [UNICODE_540C]
+    player_min_level: int = 3  # [UNICODE_30D7]
+
+
+class ResonanceCalculator:
+    """[UNICODE_5171]"""
+    
+    # [UNICODE_5171]
+    INTENSITY_MULTIPLIERS = {
+        ResonanceIntensity.WEAK: 1.5,
+        ResonanceIntensity.MODERATE: 2.0,
+        ResonanceIntensity.STRONG: 3.0,
+        ResonanceIntensity.INTENSE: 4.0
+    }
+    
+    # [UNICODE_30EC]XP[UNICODE_30DC]
+    BASE_BONUS_PER_LEVEL_DIFF = 50
+    
+    @staticmethod
+    def calculate_resonance_intensity(level_difference: int) -> ResonanceIntensity:
+        """[UNICODE_30EC]"""
+        if level_difference >= 21:
+            return ResonanceIntensity.INTENSE
+        elif level_difference >= 13:
+            return ResonanceIntensity.STRONG
+        elif level_difference >= 8:
+            return ResonanceIntensity.MODERATE
+        else:
+            return ResonanceIntensity.WEAK
+    
+    @staticmethod
+    def calculate_bonus_xp(
+        level_difference: int,
+        player_level: int,
+        resonance_type: ResonanceType
+    ) -> int:
+        """[UNICODE_30DC]XP[UNICODE_3092]"""
+        # [UNICODE_57FA]
+        base_bonus = level_difference * ResonanceCalculator.BASE_BONUS_PER_LEVEL_DIFF
+        
+        # [UNICODE_5F37]
+        intensity = ResonanceCalculator.calculate_resonance_intensity(level_difference)
+        intensity_multiplier = ResonanceCalculator.INTENSITY_MULTIPLIERS[intensity]
+        
+        # [UNICODE_30D7]
+        level_multiplier = 1.0 + (player_level * 0.05)
+        
+        # [UNICODE_5171]
+        type_multipliers = {
+            ResonanceType.LEVEL_SYNC: 1.0,
+            ResonanceType.CRYSTAL_HARMONY: 1.2,
+            ResonanceType.EMOTIONAL_BOND: 0.8,
+            ResonanceType.WISDOM_SHARING: 1.1
+        }
+        type_multiplier = type_multipliers.get(resonance_type, 1.0)
+        
+        # [UNICODE_6700]XP[UNICODE_8A08]
+        final_bonus = int(
+            base_bonus * 
+            intensity_multiplier * 
+            level_multiplier * 
+            type_multiplier
+        )
+        
+        return max(100, final_bonus)  # [UNICODE_6700]100XP[UNICODE_306F]
+    
+    @staticmethod
+    def calculate_crystal_bonuses(
+        resonance_type: ResonanceType,
+        intensity: ResonanceIntensity,
+        player_level: int
+    ) -> Dict[CrystalAttribute, int]:
+        """[UNICODE_30AF]"""
+        bonuses = {}
+        
+        # [UNICODE_5F37]
+        base_bonus = {
+            ResonanceIntensity.WEAK: 5,
+            ResonanceIntensity.MODERATE: 8,
+            ResonanceIntensity.STRONG: 12,
+            ResonanceIntensity.INTENSE: 18
+        }[intensity]
+        
+        # [UNICODE_5171]
+        if resonance_type == ResonanceType.LEVEL_SYNC:
+            # [UNICODE_30D0]
+            for attr in CrystalAttribute:
+                bonuses[attr] = base_bonus // 2
+        
+        elif resonance_type == ResonanceType.CRYSTAL_HARMONY:
+            # [UNICODE_8ABF]
+            bonuses[CrystalAttribute.WISDOM] = base_bonus
+            bonuses[CrystalAttribute.EMPATHY] = base_bonus
+            bonuses[CrystalAttribute.RESILIENCE] = base_bonus // 2
+        
+        elif resonance_type == ResonanceType.EMOTIONAL_BOND:
+            # [UNICODE_611F]
+            bonuses[CrystalAttribute.EMPATHY] = base_bonus
+            bonuses[CrystalAttribute.COMMUNICATION] = base_bonus
+            bonuses[CrystalAttribute.COURAGE] = base_bonus // 2
+        
+        elif resonance_type == ResonanceType.WISDOM_SHARING:
+            # [UNICODE_77E5]
+            bonuses[CrystalAttribute.WISDOM] = base_bonus
+            bonuses[CrystalAttribute.CURIOSITY] = base_bonus
+            bonuses[CrystalAttribute.CREATIVITY] = base_bonus // 2
+        
+        return bonuses
+    
+    @staticmethod
+    def generate_therapeutic_message(
+        resonance_type: ResonanceType,
+        intensity: ResonanceIntensity,
+        player_level: int,
+        yu_level: int
+    ) -> str:
+        """[UNICODE_6CBB]"""
+        intensity_descriptions = {
+            ResonanceIntensity.WEAK: "[UNICODE_7A4F]",
+            ResonanceIntensity.MODERATE: "[UNICODE_5FC3]",
+            ResonanceIntensity.STRONG: "[UNICODE_529B]",
+            ResonanceIntensity.INTENSE: "[UNICODE_6DF1]"
+        }
+        
+        intensity_desc = intensity_descriptions[intensity]
+        
+        messages = {
+            ResonanceType.LEVEL_SYNC: [
+                f"[UNICODE_3042]{intensity_desc}[UNICODE_5171]",
+                f"[UNICODE_30EC]{player_level}[UNICODE_306E]{yu_level}[UNICODE_306E]{intensity_desc}[UNICODE_7D46]",
+                f"{intensity_desc}[UNICODE_5171]"
+            ],
+            ResonanceType.CRYSTAL_HARMONY: [
+                f"[UNICODE_30AF]{intensity_desc}[UNICODE_8ABF]",
+                f"8[UNICODE_3064]{intensity_desc}[UNICODE_5149]",
+                f"{intensity_desc}[UNICODE_30AF]"
+            ],
+            ResonanceType.EMOTIONAL_BOND: [
+                f"[UNICODE_3042]{intensity_desc}[UNICODE_611F]",
+                f"{intensity_desc}[UNICODE_611F]",
+                f"[UNICODE_5FC3]{intensity_desc}[UNICODE_7D46]"
+            ],
+            ResonanceType.WISDOM_SHARING: [
+                f"[UNICODE_30E6]{intensity_desc}[UNICODE_5171]",
+                f"{intensity_desc}[UNICODE_77E5]",
+                f"[UNICODE_3042]{intensity_desc}[UNICODE_77E5]"
+            ]
+        }
+        
+        type_messages = messages.get(resonance_type, messages[ResonanceType.LEVEL_SYNC])
+        return random.choice(type_messages)
 
 
 class ResonanceEventManager:
-    """共鳴イベント管理"""
+    """[UNICODE_5171]"""
     
     def __init__(self):
-        self.resonance_history: List[ResonanceEvent] = []
         self.conditions = ResonanceCondition()
-        
-        # 共鳴タイプ別の設定
-        self.resonance_configs = {
-            ResonanceType.HARMONY: {
-                "base_xp": 50,
-                "crystal_bonus": 10,
-                "message": "ユウとの心が調和し、穏やかな共鳴が生まれました。"
-            },
-            ResonanceType.GROWTH: {
-                "base_xp": 75,
-                "crystal_bonus": 15,
-                "message": "ユウと共に成長の共鳴を感じています。"
-            },
-            ResonanceType.BREAKTHROUGH: {
-                "base_xp": 100,
-                "crystal_bonus": 20,
-                "message": "ユウとの強い絆が新たな突破口を開きました。"
-            },
-            ResonanceType.WISDOM: {
-                "base_xp": 125,
-                "crystal_bonus": 25,
-                "message": "ユウの深い知恵があなたの心に響いています。"
-            }
-        }
+        self.event_history: List[ResonanceEvent] = []
+        self.last_event_times: Dict[ResonanceType, datetime] = {}
     
     def check_resonance_conditions(
-        self, 
-        player_level: int, 
-        yu_level: int
+        self,
+        player_level: int,
+        yu_level: int,
+        current_time: Optional[datetime] = None
     ) -> Tuple[bool, Optional[ResonanceType]]:
-        """共鳴発生条件チェック"""
+        """[UNICODE_5171]"""
+        if current_time is None:
+            current_time = datetime.utcnow()
+        
+        # [UNICODE_57FA]
         level_difference = abs(player_level - yu_level)
         
-        # レベル差チェック
         if level_difference < self.conditions.min_level_difference:
             return False, None
         
         if level_difference > self.conditions.max_level_difference:
             return False, None
         
-        # プレイヤーレベルチェック
-        if player_level < self.conditions.required_player_level:
+        if player_level < self.conditions.player_min_level:
             return False, None
         
-        # クールダウンチェック
-        if self._is_in_cooldown():
+        # [UNICODE_30AF]
+        available_types = []
+        for resonance_type in ResonanceType:
+            last_event_time = self.last_event_times.get(resonance_type)
+            if last_event_time is None:
+                available_types.append(resonance_type)
+            else:
+                time_since_last = current_time - last_event_time
+                if time_since_last.total_seconds() >= self.conditions.cooldown_hours * 3600:
+                    available_types.append(resonance_type)
+        
+        if not available_types:
             return False, None
         
-        # 共鳴タイプ決定
-        resonance_type = self._determine_resonance_type(player_level, yu_level, level_difference)
+        # [UNICODE_5171]
+        selected_type = self._select_resonance_type(
+            level_difference, player_level, yu_level, available_types
+        )
         
-        return True, resonance_type
+        return True, selected_type
+    
+    def _select_resonance_type(
+        self,
+        level_difference: int,
+        player_level: int,
+        yu_level: int,
+        available_types: List[ResonanceType]
+    ) -> ResonanceType:
+        """[UNICODE_72B6]"""
+        # [UNICODE_30EC]
+        type_weights = {}
+        
+        for resonance_type in available_types:
+            if resonance_type == ResonanceType.LEVEL_SYNC:
+                # [UNICODE_30EC]
+                type_weights[resonance_type] = level_difference * 2
+            
+            elif resonance_type == ResonanceType.CRYSTAL_HARMONY:
+                # [UNICODE_4E2D]
+                optimal_diff = 10
+                weight = max(1, optimal_diff - abs(level_difference - optimal_diff))
+                type_weights[resonance_type] = weight * 1.5
+            
+            elif resonance_type == ResonanceType.EMOTIONAL_BOND:
+                # [UNICODE_30D7]
+                type_weights[resonance_type] = player_level * 0.5
+            
+            elif resonance_type == ResonanceType.WISDOM_SHARING:
+                # [UNICODE_30E6]
+                type_weights[resonance_type] = yu_level * 0.8
+        
+        # [UNICODE_91CD]
+        total_weight = sum(type_weights.values())
+        if total_weight == 0:
+            return random.choice(available_types)
+        
+        rand_value = random.uniform(0, total_weight)
+        cumulative_weight = 0
+        
+        for resonance_type, weight in type_weights.items():
+            cumulative_weight += weight
+            if rand_value <= cumulative_weight:
+                return resonance_type
+        
+        return available_types[0]  # [UNICODE_30D5]
     
     def trigger_resonance_event(
         self,
         player_level: int,
         yu_level: int,
-        resonance_type: ResonanceType
+        resonance_type: ResonanceType,
+        current_time: Optional[datetime] = None
     ) -> ResonanceEvent:
-        """共鳴イベント発生"""
+        """[UNICODE_5171]"""
+        if current_time is None:
+            current_time = datetime.utcnow()
+        
         level_difference = abs(player_level - yu_level)
-        intensity = self._calculate_intensity(level_difference)
+        intensity = ResonanceCalculator.calculate_resonance_intensity(level_difference)
         
-        # ボーナスXP計算
-        config = self.resonance_configs[resonance_type]
-        base_xp = config["base_xp"]
-        intensity_multiplier = self._get_intensity_multiplier(intensity)
-        bonus_xp = int(base_xp * intensity_multiplier)
-        
-        # クリスタルボーナス計算
-        crystal_bonuses = self._calculate_crystal_bonuses(
-            resonance_type, 
-            intensity, 
-            config["crystal_bonus"]
+        # [UNICODE_30DC]XP[UNICODE_8A08]
+        bonus_xp = ResonanceCalculator.calculate_bonus_xp(
+            level_difference, player_level, resonance_type
         )
         
-        # 特別報酬生成
-        special_rewards = self._generate_special_rewards(resonance_type, intensity, level_difference)
+        # [UNICODE_30AF]
+        crystal_bonuses = ResonanceCalculator.calculate_crystal_bonuses(
+            resonance_type, intensity, player_level
+        )
         
-        # 治療的メッセージ生成
-        therapeutic_message = self._generate_therapeutic_message(resonance_type, intensity)
+        # [UNICODE_7279]
+        special_rewards = self._generate_special_rewards(intensity, resonance_type)
         
-        # ストーリーアンロック判定
-        story_unlock = self._check_story_unlock(player_level, resonance_type)
+        # [UNICODE_6CBB]
+        therapeutic_message = ResonanceCalculator.generate_therapeutic_message(
+            resonance_type, intensity, player_level, yu_level
+        )
         
-        # 共鳴イベント作成
+        # [UNICODE_30B9]
+        story_unlock = self._check_story_unlock(intensity, resonance_type, player_level)
+        
+        # [UNICODE_30A4]
         event = ResonanceEvent(
+            event_id=f"resonance_{current_time.strftime('%Y%m%d_%H%M%S')}_{resonance_type.value}",
             resonance_type=resonance_type,
             intensity=intensity,
             player_level=player_level,
@@ -155,229 +346,134 @@ class ResonanceEventManager:
             crystal_bonuses=crystal_bonuses,
             special_rewards=special_rewards,
             therapeutic_message=therapeutic_message,
-            story_unlock=story_unlock
+            story_unlock=story_unlock,
+            triggered_at=current_time
         )
         
-        # 履歴に追加
-        self.resonance_history.append(event)
+        # [UNICODE_30A4]
+        self.event_history.append(event)
+        self.last_event_times[resonance_type] = current_time
         
         return event
     
-    def get_resonance_statistics(self) -> Dict[str, Any]:
-        """共鳴統計取得"""
-        total_events = len(self.resonance_history)
-        
-        if total_events == 0:
-            return {
-                "total_events": 0,
-                "last_event": None,
-                "type_distribution": {},
-                "total_bonus_xp": 0,
-                "average_bonus_xp": 0
-            }
-        
-        # タイプ別分布
-        type_distribution = {}
-        total_bonus_xp = 0
-        
-        for event in self.resonance_history:
-            event_type = event.resonance_type.value
-            type_distribution[event_type] = type_distribution.get(event_type, 0) + 1
-            total_bonus_xp += event.bonus_xp
-        
-        return {
-            "total_events": total_events,
-            "last_event": self.resonance_history[-1].triggered_at,
-            "type_distribution": type_distribution,
-            "total_bonus_xp": total_bonus_xp,
-            "average_bonus_xp": total_bonus_xp / total_events
-        }
-    
-    def simulate_resonance_probability(
-        self, 
-        player_level: int, 
-        yu_level: int, 
-        days_ahead: int = 7
-    ) -> Dict[str, Any]:
-        """共鳴確率シミュレーション"""
-        level_difference = abs(player_level - yu_level)
-        
-        # 基本確率計算
-        if level_difference < self.conditions.min_level_difference:
-            base_probability = 0.0
-        elif level_difference >= self.conditions.max_level_difference:
-            base_probability = 0.1
-        else:
-            # レベル差に基づく確率（5-20の範囲で線形増加）
-            normalized_diff = (level_difference - 5) / 15
-            base_probability = 0.3 + (normalized_diff * 0.4)  # 0.3-0.7の範囲
-        
-        # クールダウン考慮
-        if self._is_in_cooldown():
-            current_probability = 0.0
-        else:
-            current_probability = base_probability
-        
-        # 将来予測
-        future_probabilities = []
-        for day in range(1, days_ahead + 1):
-            # 簡単な予測モデル（実際はより複雑になる）
-            daily_prob = base_probability * (1 - 0.1 * day)  # 時間経過で少し減少
-            future_probabilities.append({
-                "day": day,
-                "probability": max(0.0, daily_prob)
-            })
-        
-        return {
-            "current_probability": current_probability,
-            "base_probability": base_probability,
-            "level_difference": level_difference,
-            "in_cooldown": self._is_in_cooldown(),
-            "future_predictions": future_probabilities
-        }
-    
-    # プライベートメソッド
-    
-    def _is_in_cooldown(self) -> bool:
-        """クールダウン中かチェック"""
-        if not self.resonance_history:
-            return False
-        
-        last_event = self.resonance_history[-1]
-        cooldown_end = last_event.triggered_at + timedelta(hours=self.conditions.cooldown_hours)
-        
-        return datetime.utcnow() < cooldown_end
-    
-    def _determine_resonance_type(
-        self, 
-        player_level: int, 
-        yu_level: int, 
-        level_difference: int
-    ) -> ResonanceType:
-        """共鳴タイプ決定"""
-        # プレイヤーがユウより高レベルの場合
-        if player_level > yu_level:
-            if level_difference >= 15:
-                return ResonanceType.WISDOM
-            elif level_difference >= 10:
-                return ResonanceType.BREAKTHROUGH
-            else:
-                return ResonanceType.GROWTH
-        
-        # ユウがプレイヤーより高レベルの場合
-        else:
-            if level_difference >= 15:
-                return ResonanceType.WISDOM
-            elif level_difference >= 10:
-                return ResonanceType.HARMONY
-            else:
-                return ResonanceType.GROWTH
-    
-    def _calculate_intensity(self, level_difference: int) -> ResonanceIntensity:
-        """共鳴強度計算"""
-        if level_difference >= 18:
-            return ResonanceIntensity.INTENSE
-        elif level_difference >= 12:
-            return ResonanceIntensity.STRONG
-        elif level_difference >= 8:
-            return ResonanceIntensity.MODERATE
-        else:
-            return ResonanceIntensity.GENTLE
-    
-    def _get_intensity_multiplier(self, intensity: ResonanceIntensity) -> float:
-        """強度倍率取得"""
-        multipliers = {
-            ResonanceIntensity.GENTLE: 1.0,
-            ResonanceIntensity.MODERATE: 1.2,
-            ResonanceIntensity.STRONG: 1.5,
-            ResonanceIntensity.INTENSE: 2.0
-        }
-        return multipliers.get(intensity, 1.0)
-    
-    def _calculate_crystal_bonuses(
-        self, 
-        resonance_type: ResonanceType, 
-        intensity: ResonanceIntensity,
-        base_bonus: int
-    ) -> Dict[CrystalAttribute, int]:
-        """クリスタルボーナス計算"""
-        intensity_multiplier = self._get_intensity_multiplier(intensity)
-        bonus_amount = int(base_bonus * intensity_multiplier)
-        
-        # 共鳴タイプに基づく属性選択
-        type_attributes = {
-            ResonanceType.HARMONY: [CrystalAttribute.EMPATHY, CrystalAttribute.RESILIENCE],
-            ResonanceType.GROWTH: [CrystalAttribute.CURIOSITY, CrystalAttribute.COURAGE],
-            ResonanceType.BREAKTHROUGH: [CrystalAttribute.CREATIVITY, CrystalAttribute.SELF_DISCIPLINE],
-            ResonanceType.WISDOM: [CrystalAttribute.WISDOM, CrystalAttribute.COMMUNICATION]
-        }
-        
-        attributes = type_attributes.get(resonance_type, [CrystalAttribute.SELF_DISCIPLINE])
-        
-        return {attr: bonus_amount for attr in attributes}
-    
     def _generate_special_rewards(
-        self, 
-        resonance_type: ResonanceType, 
+        self,
         intensity: ResonanceIntensity,
-        level_difference: int
+        resonance_type: ResonanceType
     ) -> List[str]:
-        """特別報酬生成"""
+        """[UNICODE_7279]"""
         rewards = []
         
-        # 強度に基づく報酬
-        if intensity == ResonanceIntensity.INTENSE:
-            rewards.append("レジェンダリーアイテム獲得")
+        # [UNICODE_5F37]
+        if intensity == ResonanceIntensity.WEAK:
+            rewards.append("resonance_crystal_fragment")
+        elif intensity == ResonanceIntensity.MODERATE:
+            rewards.extend(["resonance_crystal_fragment", "harmony_potion"])
         elif intensity == ResonanceIntensity.STRONG:
-            rewards.append("レアアイテム獲得")
+            rewards.extend(["resonance_crystal", "harmony_elixir", "bond_strengthener"])
+        elif intensity == ResonanceIntensity.INTENSE:
+            rewards.extend([
+                "legendary_resonance_crystal", "ultimate_harmony_elixir",
+                "eternal_bond_seal", "wisdom_of_ages"
+            ])
         
-        # レベル差に基づく報酬
-        if level_difference >= 15:
-            rewards.append("特別なストーリー分岐アンロック")
-        
-        # タイプ別報酬
+        # [UNICODE_30BF]
         type_rewards = {
-            ResonanceType.HARMONY: "調和の証獲得",
-            ResonanceType.GROWTH: "成長の印獲得",
-            ResonanceType.BREAKTHROUGH: "突破の勲章獲得",
-            ResonanceType.WISDOM: "知恵の宝珠獲得"
+            ResonanceType.LEVEL_SYNC: ["sync_amplifier", "level_harmony_badge"],
+            ResonanceType.CRYSTAL_HARMONY: ["crystal_tuner", "harmony_conductor"],
+            ResonanceType.EMOTIONAL_BOND: ["empathy_enhancer", "bond_deepener"],
+            ResonanceType.WISDOM_SHARING: ["wisdom_scroll", "knowledge_crystal"]
         }
         
         if resonance_type in type_rewards:
-            rewards.append(type_rewards[resonance_type])
+            rewards.extend(type_rewards[resonance_type])
         
         return rewards
     
-    def _generate_therapeutic_message(
-        self, 
-        resonance_type: ResonanceType, 
-        intensity: ResonanceIntensity
-    ) -> str:
-        """治療的メッセージ生成"""
-        base_message = self.resonance_configs[resonance_type]["message"]
-        
-        # 強度に基づくメッセージ拡張
-        intensity_additions = {
-            ResonanceIntensity.GENTLE: "この穏やかな瞬間を大切にしてください。",
-            ResonanceIntensity.MODERATE: "あなたの努力が実を結んでいます。",
-            ResonanceIntensity.STRONG: "素晴らしい成長を遂げていますね。",
-            ResonanceIntensity.INTENSE: "あなたの変化は本当に驚くべきものです。"
-        }
-        
-        addition = intensity_additions.get(intensity, "")
-        
-        return f"{base_message} {addition}".strip()
-    
     def _check_story_unlock(
-        self, 
-        player_level: int, 
-        resonance_type: ResonanceType
+        self,
+        intensity: ResonanceIntensity,
+        resonance_type: ResonanceType,
+        player_level: int
     ) -> Optional[str]:
-        """ストーリーアンロック判定"""
-        # 特定条件でストーリーアンロック
-        if player_level >= 10 and resonance_type == ResonanceType.BREAKTHROUGH:
-            return "special_chapter_breakthrough"
-        elif player_level >= 20 and resonance_type == ResonanceType.WISDOM:
-            return "wisdom_path_unlock"
+        """[UNICODE_30B9]"""
+        # [UNICODE_5F37]
+        if intensity in [ResonanceIntensity.STRONG, ResonanceIntensity.INTENSE]:
+            story_unlocks = {
+                ResonanceType.LEVEL_SYNC: "resonance_sync_chapter",
+                ResonanceType.CRYSTAL_HARMONY: "crystal_harmony_chapter",
+                ResonanceType.EMOTIONAL_BOND: "emotional_bond_chapter",
+                ResonanceType.WISDOM_SHARING: "wisdom_sharing_chapter"
+            }
+            
+            # [UNICODE_30D7]
+            if player_level >= 10:
+                return story_unlocks.get(resonance_type)
         
         return None
+    
+    def get_resonance_statistics(self) -> Dict:
+        """[UNICODE_5171]"""
+        if not self.event_history:
+            return {
+                "total_events": 0,
+                "events_by_type": {},
+                "events_by_intensity": {},
+                "total_bonus_xp": 0,
+                "average_bonus_xp": 0,
+                "last_event": None
+            }
+        
+        # [UNICODE_30BF]
+        events_by_type = {}
+        for event in self.event_history:
+            event_type = event.resonance_type.value
+            events_by_type[event_type] = events_by_type.get(event_type, 0) + 1
+        
+        # [UNICODE_5F37]
+        events_by_intensity = {}
+        for event in self.event_history:
+            intensity = event.intensity.value
+            events_by_intensity[intensity] = events_by_intensity.get(intensity, 0) + 1
+        
+        # XP[UNICODE_7D71]
+        total_bonus_xp = sum(event.bonus_xp for event in self.event_history)
+        average_bonus_xp = total_bonus_xp / len(self.event_history)
+        
+        return {
+            "total_events": len(self.event_history),
+            "events_by_type": events_by_type,
+            "events_by_intensity": events_by_intensity,
+            "total_bonus_xp": total_bonus_xp,
+            "average_bonus_xp": average_bonus_xp,
+            "last_event": self.event_history[-1].triggered_at if self.event_history else None
+        }
+    
+    def simulate_resonance_probability(
+        self,
+        player_level: int,
+        yu_level: int,
+        days_ahead: int = 7
+    ) -> Dict:
+        """[UNICODE_5171]"""
+        current_time = datetime.utcnow()
+        simulation_results = []
+        
+        for day in range(days_ahead):
+            sim_time = current_time + timedelta(days=day)
+            can_resonate, resonance_type = self.check_resonance_conditions(
+                player_level, yu_level, sim_time
+            )
+            
+            simulation_results.append({
+                "day": day + 1,
+                "can_resonate": can_resonate,
+                "resonance_type": resonance_type.value if resonance_type else None,
+                "level_difference": abs(player_level - yu_level)
+            })
+        
+        return {
+            "simulation_days": days_ahead,
+            "results": simulation_results,
+            "resonance_possible_days": sum(1 for r in simulation_results if r["can_resonate"])
+        }

--- a/shared/repositories/__init__.py
+++ b/shared/repositories/__init__.py
@@ -6,7 +6,6 @@ Exports all repository classes for easy importing
 from .base_repository import BaseRepository, CachedRepository
 from .user_repository import UserRepository
 from .task_repository import TaskRepository
-from .story_repository import StoryRepository
 from .mood_repository import MoodRepository
 from .mandala_repository import MandalaRepository
 from .game_state_repository import GameStateRepository
@@ -27,7 +26,6 @@ __all__ = [
     # Core repositories
     "UserRepository",
     "TaskRepository", 
-    "StoryRepository",
     "MoodRepository",
     "MandalaRepository",
     "GameStateRepository",

--- a/shared/utils/exceptions.py
+++ b/shared/utils/exceptions.py
@@ -29,6 +29,26 @@ class BusinessLogicError(TherapeuticGameError):
         super().__init__(message, "BUSINESS_LOGIC_ERROR")
         self.operation = operation
 
+
+class DatabaseError(TherapeuticGameError):
+    """Database operation error"""
+
+    def __init__(self, message: str = "Database operation failed"):
+        super().__init__(message, "DATABASE_ERROR")
+
+
+class NotFoundError(TherapeuticGameError):
+    """Generic not found error"""
+
+    def __init__(self, entity: str, entity_id: Optional[str] = None):
+        details = {"entity": entity}
+        if entity_id is not None:
+            details["id"] = entity_id
+            message = f"{entity} not found: {entity_id}"
+        else:
+            message = f"{entity} not found"
+        super().__init__(message, "NOT_FOUND", details=details)
+
 class AuthenticationError(TherapeuticGameError):
     """Authentication related errors"""
     
@@ -175,9 +195,11 @@ EXCEPTION_STATUS_MAP = {
     UserNotFoundError: 404,
     TaskNotFoundError: 404,
     ItemNotFoundError: 404,
+    NotFoundError: 404,
     DailyTaskLimitExceededError: 429,
     RateLimitExceededError: 429,
     DatabaseConnectionError: 503,
+    DatabaseError: 500,
     ExternalAPIError: 502,
     TherapeuticGameError: 500,  # Default for base exception
 }


### PR DESCRIPTION
## Summary
- Restore dataclass-based Mandala system and validation utilities
- Reintroduce original resonance calculator and event manager
- Add missing crystal API models and generic NotFound/Database exceptions
- Simplify repository exports to avoid missing StoryRepository

## Testing
- `pytest shared/tests/ -v --cov=shared --cov-report=xml --cov-report=html` *(fails: 58 failed, 122 passed, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6894be01df388333849c040b0ee93511